### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Java Build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/useful-toys/slf4j-toys/security/code-scanning/1](https://github.com/useful-toys/slf4j-toys/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `actions/checkout` step requires `contents: read` to access the repository code.
- The `codecov/codecov-action` step requires `contents: read` and possibly `statuses: write` to upload coverage reports and update commit statuses.

We will set these permissions explicitly to ensure the workflow operates securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
