### PR TITLE
build: update dependencies and plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,8 @@
         <!-- Production Dependencies Versions -->
         <slf4j.version>2.0.18</slf4j.version>
         <!-- Logback versions for different SLF4J/Servlet combinations -->
-        <logback.version>1.5.24</logback.version>
-        <logback-javax.version>1.3.14</logback-javax.version>
+        <logback.version>1.5.37</logback.version>
+        <logback-javax.version>1.3.16</logback-javax.version>
         <logback-legacy.version>1.2.13</logback-legacy.version>
         <!-- Servlet API versions -->
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
@@ -567,7 +567,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <logback.version>1.5.23</logback.version>
+                <logback.version>1.5.37</logback.version>
             </properties>
             <dependencies>
                 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -185,18 +185,18 @@
         <jansi.version>1.18</jansi.version>
 
         <!-- Testing Dependencies Versions -->
-        <junit5.version>5.14.3</junit5.version>
+        <junit5.version>5.14.4</junit5.version>
         <!-- Defaults to 5.x for Java 11+ (can be overridden by JDK profiles) -->
-        <mockito.version>5.21.0</mockito.version>
+        <mockito.version>5.23.0</mockito.version>
         <awaitility.version>4.3.0</awaitility.version>
         <slf4j-test-mock.version>0.0.12</slf4j-test-mock.version>
-        <archunit.version>1.4.1</archunit.version>
+        <archunit.version>1.4.2</archunit.version>
 
         <!-- Maven Plugins Versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.4.0</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
@@ -205,7 +205,7 @@
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
 
         <!-- Build Configuration -->

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Production Dependencies Versions -->
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <!-- Logback versions for different SLF4J/Servlet combinations -->
         <logback.version>1.5.24</logback.version>
         <logback-javax.version>1.3.14</logback-javax.version>
@@ -180,7 +180,7 @@
         <!-- Servlet API versions -->
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-        <lombok.version>1.18.42</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
         <log4j.version>2.12.1</log4j.version>
         <jansi.version>1.18</jansi.version>
 
@@ -195,10 +195,10 @@
         <!-- Maven Plugins Versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
-        <maven-resources-plugin.version>3.4.0</maven-resources-plugin.version>
+        <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
-        <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
@@ -206,7 +206,7 @@
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
-        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
 
         <!-- Build Configuration -->
         <!-- Enforcer defaults to enabled for JDK 21, skipped for other JDKs -->


### PR DESCRIPTION
## Resumo

Atualizacao de dependencias de teste, core e plugins Maven. Todos os **2998 testes passando**.

### Dependencias de Teste
- junit-jupiter: 5.14.3 → 5.14.4
- mockito-core: 5.21.0 → 5.23.0
- archunit: 1.4.1 → 1.4.2

### Dependencias Core
- lombok: 1.18.42 → 1.18.46
- slf4j-api: 2.0.17 → 2.0.18
- logback (1.5.x): 1.5.24 → 1.5.37
- logback-javax (1.3.x): 1.3.14 → 1.3.16

### Plugins Maven
- maven-surefire-plugin: 3.5.5 → 3.5.6
- jacoco-maven-plugin: 0.8.14 → 0.8.15
- maven-enforcer-plugin: 3.6.2 → 3.6.3
- maven-resources-plugin: 3.4.0 → 3.5.0
- central-publishing-maven-plugin: 0.10.0 → 0.11.0
