### PR TITLE
test: fix flaky Meter dirty-stack validation under GC

### DIFF
--- a/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalWeakReferenceGcTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalWeakReferenceGcTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.impl.MockLogger;
+import org.slf4j.impl.MockLoggerEvent;
+import org.usefultoys.slf4j.LoggerFactory;
+import org.usefultoys.test.ValidateCleanMeter;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * <b>Diagnostic test (test-only, no production impact).</b>
+ * <p>
+ * This class exists to turn the flaky-test hypothesis into a reproducible fact. It demonstrates,
+ * deterministically, that the {@link Meter} thread-local stack can silently lose its top element
+ * because it is held through a {@link WeakReference} (see {@code Meter.localThreadInstance}).
+ * <p>
+ * The flaky failure observed in CI
+ * ({@code MeterLifeCyclePostStartConfigurationTest.shouldDoubleIncrementIterationCounterWithIncTwiceAfterStart})
+ * is caused by the following sequence:
+ * <ol>
+ *   <li>A {@code Meter} is started but never stopped; the only strong reference is a local variable.</li>
+ *   <li>When that variable goes out of scope, the {@code Meter} becomes weakly reachable.</li>
+ *   <li>If the garbage collector runs before the stack is inspected, the {@code WeakReference}
+ *       clears and {@link Meter#getCurrentInstance()} returns the dummy {@code "???"} Meter,
+ *       even though the operation was never terminated.</li>
+ * </ol>
+ * <p>
+ * Because the garbage collector is non-deterministic, the production failure is intermittent.
+ * Here we make it deterministic by driving the collector until a weak canary is cleared, and
+ * only then asserting the resulting state. If the collector cannot be triggered in this
+ * environment (for example, under {@code -XX:+DisableExplicitGC}), the affected test is skipped
+ * via {@link org.junit.jupiter.api.Assumptions} rather than reported as a false failure.
+ *
+ * @author Daniel Felix Ferber
+ */
+@ValidateCleanMeter
+@DisplayName("Diagnostic: WeakReference in Meter ThreadLocal loses the started Meter on GC")
+class MeterThreadLocalWeakReferenceGcTest {
+
+    private static final String UNKNOWN = Meter.UNKNOWN_LOGGER_NAME;
+    private static final String CATEGORY = "weakref.gc.diagnostic";
+    private final Logger logger = LoggerFactory.getLogger(CATEGORY);
+
+    /** Sink to keep the allocation pressure from being optimized away by the JIT. */
+    @SuppressWarnings("unused")
+    private static volatile long blackhole;
+
+    /**
+     * Drives the garbage collector until a freshly allocated weak canary is reclaimed,
+     * proving that a full collection cycle actually happened. Combines {@link System#gc()}
+     * hints with real allocation pressure so it works even when explicit GC is a no-op.
+     *
+     * @return {@code true} if a collection cycle was observed within the time budget,
+     *         {@code false} if the collector could not be triggered (test should be skipped).
+     */
+    private static boolean forceGarbageCollection() {
+        Object canary = new Object();
+        final WeakReference<Object> canaryRef = new WeakReference<>(canary);
+        // Drop the only strong reference so the canary becomes collectable.
+        canary = null;
+
+        final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (canaryRef.get() != null) {
+            if (System.nanoTime() > deadlineNanos) {
+                return false;
+            }
+            System.gc();
+            System.runFinalization();
+            // Real allocation pressure: provokes collection even if System.gc() is only a hint.
+            final byte[] pressure = new byte[8 * 1024 * 1024];
+            blackhole += pressure.length;
+        }
+        return true;
+    }
+
+    /**
+     * <b>Control / sanity check.</b> While a started Meter is kept strongly reachable, garbage
+     * collection must NOT remove it from the thread-local stack. This isolates the
+     * {@link WeakReference} as the sole cause of the loss: if even a strongly referenced Meter
+     * vanished, the test harness itself would be suspect.
+     */
+    @Test
+    @DisplayName("A strongly referenced started Meter survives GC and stays on the stack")
+    void stronglyReferencedMeterSurvivesGc() {
+        assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
+
+        final Meter meter = new Meter(logger).start();
+        assertEquals(CATEGORY, Meter.getCurrentInstance().getCategory(), "Meter must be active right after start()");
+
+        assumeTrue(forceGarbageCollection(), "Could not trigger GC in this environment; skipping");
+
+        // 'meter' is still strongly referenced by the local variable here.
+        assertEquals(CATEGORY, Meter.getCurrentInstance().getCategory(),
+                "A strongly referenced Meter must remain on the stack after GC");
+
+        // Explicit cleanup so the stack is left clean for the next test.
+        meter.ok();
+        assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Stack must be clean after ok()");
+    }
+
+    /**
+     * <b>Reproduces the production flake deterministically.</b> A Meter is started and never
+     * stopped, and no strong reference is retained — exactly the situation of the failing test
+     * once its local variable goes out of scope. After a forced GC, the {@link WeakReference}
+     * clears and the stack reports {@code "???"}, i.e. the started Meter is silently lost.
+     * <p>
+     * This test PASSES against the current code, which is precisely the proof that the current
+     * behavior is non-deterministic with respect to garbage collection. If the {@code WeakReference}
+     * were removed (strong reference), this assertion would no longer hold — see the companion
+     * guarantee test that should accompany that change.
+     */
+    @Test
+    @DisplayName("A non-referenced started Meter is lost from the stack after GC (the flake)")
+    void weakReferenceLosesStartedMeterAfterGc() {
+        assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
+
+        // Start a Meter but keep NO strong reference to it. This mirrors a test/operation that
+        // starts a Meter and never terminates it, then lets the local variable go out of scope.
+        new Meter(logger).start();
+        assertEquals(CATEGORY, Meter.getCurrentInstance().getCategory(),
+                "Meter must be active immediately after start(), before GC");
+
+        assumeTrue(forceGarbageCollection(), "Could not trigger GC in this environment; skipping");
+
+        assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(),
+                "BUG REPRODUCED: the started Meter was held only through a WeakReference and was "
+                        + "collected by the GC, so the stack now reports the dummy '???' Meter even "
+                        + "though the operation was never terminated. This is the root cause of the "
+                        + "intermittent CI failure.");
+    }
+
+    /**
+     * Same mechanism, framed as the exact symptom seen by the validation extension: a test that
+     * leaves a Meter on the stack (expecting a "dirty" stack) can instead observe a "clean" stack
+     * after GC. This documents why {@code @ValidateCleanMeter(expectDirtyStack = true)} is racy
+     * under the current {@code WeakReference} design.
+     */
+    @Test
+    @DisplayName("An 'expected dirty' stack can appear clean after GC under WeakReference")
+    void expectedDirtyStackCanAppearCleanAfterGc() {
+        assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
+
+        new Meter(logger).start().inc().inc();
+        assertNotEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(),
+                "Stack is dirty right after start()/inc(), as the test author intended");
+
+        assumeTrue(forceGarbageCollection(), "Could not trigger GC in this environment; skipping");
+
+        assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(),
+                "After GC the WeakReference cleared and the 'dirty' stack now looks clean — this is "
+                        + "exactly the contradiction that makes expectDirtyStack=true tests flaky.");
+    }
+
+    /**
+     * <b>Positive guarantee of the production requirement.</b>
+     * <p>
+     * In a Java EE / server backend the library must stay resilient even when application code
+     * forgets to terminate a {@code Meter} ({@code ok()}/{@code reject()}/{@code fail()}/{@code close()}).
+     * The required behavior is:
+     * <ol>
+     *   <li><b>No memory leak:</b> a forgotten, started {@code Meter} must be reclaimable by the GC,
+     *       never pinned forever by the thread-local stack.</li>
+     *   <li><b>Inconsistency is logged:</b> when such a forgotten {@code Meter} is reclaimed, an error
+     *       message must be emitted so the misuse is visible.</li>
+     *   <li><b>Resilience:</b> the thread-local stack must self-heal back to the dummy {@code "???"}.</li>
+     * </ol>
+     * This test proves that the current {@code WeakReference}-based design satisfies all three, and
+     * therefore that removing the {@code WeakReference} (which would pin the chain in a pooled thread
+     * and also prevent {@code finalize()} from ever logging) must NOT be done under this requirement.
+     */
+    @Test
+    @DisplayName("REQUIREMENT: a forgotten Meter is reclaimed (no leak), logs a warning, and the stack self-heals")
+    void forgottenMeterIsReclaimedWithoutLeakAndLogsWarning() {
+        assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
+
+        // Resolve the exact logger the Meter reports to (category, wrapped by the configured prefix/suffix).
+        final MockLogger messageLogger = (MockLogger) LoggerFactory.getLogger(
+                MeterConfig.messagePrefix + CATEGORY + MeterConfig.messageSuffix);
+        messageLogger.clearEvents();
+
+        // Start a Meter and "forget" it: keep NO strong reference. A WeakReference lets us observe
+        // whether it becomes collectable without itself preventing collection.
+        final WeakReference<Meter> tracker = new WeakReference<>(new Meter(logger).start());
+        assertEquals(CATEGORY, Meter.getCurrentInstance().getCategory(),
+                "Meter must be active immediately after start()");
+
+        // Drive GC + finalization until the Meter is reclaimed AND its finalize() warning is logged.
+        final boolean reclaimedAndWarned = driveReclamationAndFinalization(tracker, messageLogger);
+        assumeTrue(reclaimedAndWarned, "Could not trigger GC/finalization in this environment; skipping");
+
+        // (1) NO MEMORY LEAK: nothing retained the forgotten Meter, so the GC reclaimed it.
+        assertNull(tracker.get(),
+                "A forgotten started Meter must be garbage-collectable: the WeakReference design "
+                        + "guarantees no unbounded retention in a pooled thread — i.e. no memory leak.");
+
+        // (2) INCONSISTENCY LOGGED: finalize() reported the never-stopped Meter.
+        assertTrue(hasNeverStoppedWarning(messageLogger),
+                "Reclaiming a started-but-never-stopped Meter must log an inconsistency warning "
+                        + "('Meter never stopped...') so the misuse is visible.");
+
+        // (3) RESILIENCE: the thread-local stack self-healed to the dummy Meter.
+        assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(),
+                "After reclamation the thread-local stack must self-heal back to the dummy '???' Meter.");
+    }
+
+    /**
+     * Drives garbage collection and finalization until the tracked Meter has been reclaimed AND its
+     * {@code finalize()} warning has been logged, or until the time budget expires.
+     *
+     * @return {@code true} if both reclamation and the warning were observed in time; {@code false}
+     *         if the collector/finalizer could not be driven (the test should then be skipped).
+     */
+    @SuppressWarnings({"removal", "deprecation"})
+    private static boolean driveReclamationAndFinalization(
+            final WeakReference<Meter> tracker, final MockLogger messageLogger) {
+        final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        while (System.nanoTime() < deadlineNanos) {
+            System.gc();
+            System.runFinalization();
+            final byte[] pressure = new byte[8 * 1024 * 1024];
+            blackhole += pressure.length;
+            if (tracker.get() == null && hasNeverStoppedWarning(messageLogger)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Defensively scans the logger for the finalize() inconsistency warning. Tolerates concurrent
+     * writes from the finalizer thread by snapshotting and retrying on the next poll iteration.
+     */
+    private static boolean hasNeverStoppedWarning(final MockLogger messageLogger) {
+        try {
+            for (final MockLoggerEvent event : new ArrayList<>(messageLogger.getLoggerEvents())) {
+                final String formatted = event.getFormattedMessage();
+                if (event.getLevel() == MockLoggerEvent.Level.ERROR
+                        && formatted != null
+                        && formatted.contains("Meter never stopped")) {
+                    return true;
+                }
+            }
+        } catch (final ConcurrentModificationException ignored) {
+            // The finalizer thread is appending concurrently; treat as "not yet" and retry.
+        }
+        return false;
+    }
+}

--- a/src/test/java/org/usefultoys/test/ValidateCleanMeterExtension.java
+++ b/src/test/java/org/usefultoys/test/ValidateCleanMeterExtension.java
@@ -58,18 +58,29 @@ import java.util.Optional;
  * This approach provides both resilience (removes leftover state) and visibility
  * (fails if current test leaves the stack dirty when it shouldn't).
  * <p>
- * <b>Determinism under garbage collection:</b> the Meter thread-local stack holds each Meter through
- * a {@link java.lang.ref.WeakReference} (so that a forgotten, never-stopped Meter can be reclaimed in
- * a server/Java EE environment without leaking memory). For a test annotated with
- * {@code expectDirtyStack = true}, the started Meter is typically only reachable through a local
- * variable that dies when the test body returns. JUnit's allocation-heavy post-test machinery could
- * then trigger a GC that clears the WeakReference before {@code afterEach} inspects the stack, making
- * the "dirty stack" assertion intermittently fail. To prevent this, this extension also implements
- * {@link InvocationInterceptor}: immediately after the test body returns — before any allocation that
- * could trigger a GC — it pins the current top of the stack in a strong reference held by the per-test
- * {@link ExtensionContext.Store}. That strong reference keeps the WeakReference valid, so the
- * {@code afterEach} validation observes the real Meter deterministically. This is a test-only
- * mechanism; the production WeakReference behavior is unchanged.
+ * <b>Shrinking the garbage-collection race for {@code expectDirtyStack = true} tests:</b> the Meter
+ * thread-local stack holds each Meter through a {@link java.lang.ref.WeakReference} (so that a
+ * forgotten, never-stopped Meter can be reclaimed in a server/Java EE environment without leaking
+ * memory). For a test annotated with {@code expectDirtyStack = true}, the started Meter is typically
+ * only reachable through a local variable that dies when the test body returns. JUnit's
+ * allocation-heavy post-test machinery could then trigger a GC that clears the WeakReference before
+ * {@code afterEach} inspects the stack, making the "dirty stack" assertion intermittently fail. To
+ * counter this, this extension also implements {@link InvocationInterceptor}: as soon as the test body
+ * returns — before JUnit's post-test machinery runs — it captures the current top of the stack into a
+ * strong reference held by the per-test {@link ExtensionContext.Store}, which keeps the WeakReference
+ * valid through {@code afterEach}.
+ * <p>
+ * <b>Honest scope of the guarantee:</b> this does <em>not</em> make collection mathematically
+ * impossible. A few instructions still run between the body returning and the capture (interceptor
+ * chain unwinding, safepoints, and the {@code Store} lookup), and a sufficiently aggressive collector
+ * could in theory still reclaim the Meter in that window. What the interceptor does is shrink the race
+ * from the <em>thousands</em> of allocations performed by JUnit's post-test processing down to a
+ * handful, which empirically eliminates the observed flake (it reproduces ~1/3 of runs without this
+ * mechanism under {@code -Xmx64m -XX:+UseSerialGC}, and 0/many with it). A mathematically hard
+ * guarantee would instead require holding a strong reference to the Meter from the moment it is
+ * started (e.g. a per-test field on every such test), which was rejected here for the churn of
+ * touching ~100 tests. This is a test-only mechanism; the production WeakReference behavior is
+ * unchanged.
  * <p>
  * <b>Usage:</b>
  * <pre>{@code
@@ -135,21 +146,29 @@ public class ValidateCleanMeterExtension implements BeforeEachCallback, AfterEac
     }
 
     /**
-     * Pins the current top of the Meter thread-local stack in a strong reference held by the per-test
-     * {@link ExtensionContext.Store}.
+     * Captures the current top of the Meter thread-local stack into a strong reference held by the
+     * per-test {@link ExtensionContext.Store}.
      * <p>
-     * This runs right after the test body returns and before JUnit's allocation-heavy post-test
-     * machinery. {@link Meter#getCurrentInstance()} performs no allocation when the stack is dirty,
-     * and there is no allocation between the test body returning and this read, so no garbage
-     * collection can clear the underlying {@code WeakReference} before the real Meter is captured.
-     * Holding the strong reference also keeps that {@code WeakReference} valid through {@code afterEach},
-     * which makes the dirty/clean stack validation deterministic. Pinning the dummy "unknown" Meter
-     * (when the stack is clean) is harmless.
+     * The current Meter is read into a strong local <em>before</em> the {@code Store} is touched, so
+     * that any allocation performed by {@code getStore()}/{@code put()} (e.g. lazily creating the
+     * namespaced store) happens only after a strong reference already protects the Meter — closing the
+     * ordering gap where a GC during the store lookup could otherwise reclaim it.
+     * {@link Meter#getCurrentInstance()} itself performs no allocation when the stack is dirty. Holding
+     * the strong reference keeps the underlying {@code WeakReference} valid through {@code afterEach},
+     * making the dirty/clean validation reliable in practice.
+     * <p>
+     * This shrinks but does not fully close the GC window: a few instructions (interceptor unwinding,
+     * safepoints) still run between the body returning and this capture — see the class Javadoc for the
+     * honest scope of the guarantee. Pinning the dummy "unknown" Meter (when the stack is clean) is
+     * harmless.
      *
      * @param context the current extension context whose store retains the strong reference
      */
     private static void pinCurrentMeterStack(final ExtensionContext context) {
-        context.getStore(NAMESPACE).put(PINNED_METER_KEY, Meter.getCurrentInstance());
+        // Read the strong reference FIRST, then store it: storing may allocate, but by then the Meter
+        // is already protected by the 'current' local.
+        final Meter current = Meter.getCurrentInstance();
+        context.getStore(NAMESPACE).put(PINNED_METER_KEY, current);
     }
 
     /**

--- a/src/test/java/org/usefultoys/test/ValidateCleanMeterExtension.java
+++ b/src/test/java/org/usefultoys/test/ValidateCleanMeterExtension.java
@@ -19,8 +19,12 @@ package org.usefultoys.test;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.usefultoys.slf4j.meter.Meter;
 
+import java.lang.reflect.Method;
 import java.util.Optional;
 
 /**
@@ -54,6 +58,19 @@ import java.util.Optional;
  * This approach provides both resilience (removes leftover state) and visibility
  * (fails if current test leaves the stack dirty when it shouldn't).
  * <p>
+ * <b>Determinism under garbage collection:</b> the Meter thread-local stack holds each Meter through
+ * a {@link java.lang.ref.WeakReference} (so that a forgotten, never-stopped Meter can be reclaimed in
+ * a server/Java EE environment without leaking memory). For a test annotated with
+ * {@code expectDirtyStack = true}, the started Meter is typically only reachable through a local
+ * variable that dies when the test body returns. JUnit's allocation-heavy post-test machinery could
+ * then trigger a GC that clears the WeakReference before {@code afterEach} inspects the stack, making
+ * the "dirty stack" assertion intermittently fail. To prevent this, this extension also implements
+ * {@link InvocationInterceptor}: immediately after the test body returns — before any allocation that
+ * could trigger a GC — it pins the current top of the stack in a strong reference held by the per-test
+ * {@link ExtensionContext.Store}. That strong reference keeps the WeakReference valid, so the
+ * {@code afterEach} validation observes the real Meter deterministically. This is a test-only
+ * mechanism; the production WeakReference behavior is unchanged.
+ * <p>
  * <b>Usage:</b>
  * <pre>{@code
  * @ExtendWith(ValidateCleanMeterExtension.class)
@@ -70,7 +87,70 @@ import java.util.Optional;
  * @see Meter#UNKNOWN_LOGGER_NAME
  * @author Daniel Felix Ferber
  */
-public class ValidateCleanMeterExtension implements BeforeEachCallback, AfterEachCallback {
+public class ValidateCleanMeterExtension implements BeforeEachCallback, AfterEachCallback, InvocationInterceptor {
+
+    /** Namespace for storing the per-test strong reference that pins the Meter stack against GC. */
+    private static final Namespace NAMESPACE = Namespace.create(ValidateCleanMeterExtension.class);
+    /** Store key for the pinned top-of-stack Meter (kept strongly reachable through afterEach). */
+    private static final String PINNED_METER_KEY = "pinnedMeter";
+
+    /**
+     * Intercepts a plain {@code @Test} method to pin the Meter stack immediately after the test body
+     * returns. See the class-level Javadoc for the rationale.
+     *
+     * @param invocation        the test method invocation to proceed
+     * @param invocationContext reflective information about the invocation (unused)
+     * @param extensionContext  the current extension context
+     * @throws Throwable if the underlying test invocation throws
+     */
+    @Override
+    public void interceptTestMethod(final Invocation<Void> invocation,
+            final ReflectiveInvocationContext<Method> invocationContext,
+            final ExtensionContext extensionContext) throws Throwable {
+        try {
+            invocation.proceed();
+        } finally {
+            pinCurrentMeterStack(extensionContext);
+        }
+    }
+
+    /**
+     * Intercepts template-based tests ({@code @ParameterizedTest}, {@code @RepeatedTest}) to pin the
+     * Meter stack immediately after the test body returns, for the same reason as plain tests.
+     *
+     * @param invocation        the test method invocation to proceed
+     * @param invocationContext reflective information about the invocation (unused)
+     * @param extensionContext  the current extension context
+     * @throws Throwable if the underlying test invocation throws
+     */
+    @Override
+    public void interceptTestTemplateMethod(final Invocation<Void> invocation,
+            final ReflectiveInvocationContext<Method> invocationContext,
+            final ExtensionContext extensionContext) throws Throwable {
+        try {
+            invocation.proceed();
+        } finally {
+            pinCurrentMeterStack(extensionContext);
+        }
+    }
+
+    /**
+     * Pins the current top of the Meter thread-local stack in a strong reference held by the per-test
+     * {@link ExtensionContext.Store}.
+     * <p>
+     * This runs right after the test body returns and before JUnit's allocation-heavy post-test
+     * machinery. {@link Meter#getCurrentInstance()} performs no allocation when the stack is dirty,
+     * and there is no allocation between the test body returning and this read, so no garbage
+     * collection can clear the underlying {@code WeakReference} before the real Meter is captured.
+     * Holding the strong reference also keeps that {@code WeakReference} valid through {@code afterEach},
+     * which makes the dirty/clean stack validation deterministic. Pinning the dummy "unknown" Meter
+     * (when the stack is clean) is harmless.
+     *
+     * @param context the current extension context whose store retains the strong reference
+     */
+    private static void pinCurrentMeterStack(final ExtensionContext context) {
+        context.getStore(NAMESPACE).put(PINNED_METER_KEY, Meter.getCurrentInstance());
+    }
 
     /**
      * Ensures that the Meter stack is clean before the test starts.


### PR DESCRIPTION
## Problem

Tests annotated with `@ValidateCleanMeter(expectDirtyStack = true)` start a `Meter` and **intentionally** leave it on the per-thread stack, so that `afterEach` can assert the stack is "dirty" (i.e. an operation is still in progress). These tests failed **intermittently** in CI (JDK 21 / `slf4j-2.0-javax`, ~1 in 4 matrix runs, always passing on re-run):

```
Meter stack was expected to be dirty after test '...', but found clean stack (unknown Meter).
Test is annotated with @ValidateCleanMeter(expectDirtyStack = true),
but did not leave any Meter on the stack.
```

## Root cause

The per-thread stack holds each `Meter` through a `WeakReference`:

```java
private static final ThreadLocal<WeakReference<Meter>> localThreadInstance = new ThreadLocal<>();
```

This is an **intentional production feature**, not a bug. In a server / Java EE environment, a `Meter` that is started but never terminated (a forgotten `ok()`/`reject()`/`fail()`/`close()`) must remain **garbage-collectable** so the application **never leaks memory**. A strong reference would instead pin an unbounded `previousInstance` chain to a pooled thread forever — and would also prevent `finalize()` from ever logging the "Meter never stopped" warning. So the `WeakReference` must stay.

The flakiness is therefore a **test defect**, not a library defect:

1. The test body runs `final Meter meter = new Meter(logger).start();` — a **local variable** is the only strong reference; the `Meter` is pushed onto the stack as a `WeakReference`.
2. The test body returns. The local `meter` dies → the `Meter` is now only **weakly reachable**.
3. JUnit's post-test machinery (result recording, reporting, callbacks) runs and **allocates**, which can trigger a GC.
4. If a GC runs in that window, it clears the `WeakReference` and the `Meter` is collected.
5. `afterEach` → `validateMeterStackIsDirty()` → `Meter.getCurrentInstance()` returns the dummy `"???"` Meter → the "expected dirty" assertion fails.

In short, the test relied on the GC **not** running between the test body and `afterEach` — a property the design (correctly) does not guarantee.

## Proposed solution

**Scope: test-only. `Meter.java` is unchanged; the production `WeakReference` behavior is preserved.**

`ValidateCleanMeterExtension` (which already owns the dirty/clean validation) now also implements `InvocationInterceptor`. As soon as the test body returns — before JUnit's allocation-heavy post-test machinery runs — it captures the top of the stack into a strong reference held by the per-test `ExtensionContext.Store`, which keeps the `WeakReference` valid through `afterEach`. This mirrors how production code holds the `Meter` in a local while the operation is in flight.

```java
@Override
public void interceptTestMethod(Invocation<Void> invocation,
        ReflectiveInvocationContext<Method> invocationContext,
        ExtensionContext extensionContext) throws Throwable {
    try {
        invocation.proceed();                  // run the test body
    } finally {
        pinCurrentMeterStack(extensionContext);
    }
}

private static void pinCurrentMeterStack(ExtensionContext context) {
    // Read the strong reference FIRST, then store it: getStore()/put() may allocate, but by then
    // the Meter is already protected by the 'current' local.
    final Meter current = Meter.getCurrentInstance();
    context.getStore(NAMESPACE).put(PINNED_METER_KEY, current);
}
```

Two details make this work:

- **The capture runs at the earliest point** — right after `invocation.proceed()`, before the window where the documented failure actually happens (JUnit's post-test allocations).
- **The strong reference is taken before any allocation in the pin itself.** `getCurrentInstance()` is read into a local *before* `getStore()` is touched. (`getStore()` is the receiver of `.put()` and is evaluated before its arguments, so the naive one-liner `getStore().put(KEY, getCurrentInstance())` would allocate the namespaced store *before* capturing the Meter — an ordering gap fixed here.) `getCurrentInstance()` itself does not allocate when the stack is dirty.

`interceptTestTemplateMethod` is implemented too, covering `@ParameterizedTest` / `@RepeatedTest`.

### Honest scope of the guarantee

This **shrinks** the GC race; it does **not** make collection mathematically impossible. A few instructions still run between the test body returning and the capture — interceptor-chain unwinding, safepoints, and the `Store` lookup — and a sufficiently aggressive collector could in theory still reclaim the Meter there. What the interceptor achieves is reducing the window from the **thousands** of allocations in JUnit's post-test processing down to a **handful**, which empirically eliminates the observed flake.

A mathematically hard guarantee would instead require holding a strong reference to the Meter from the moment it is started (e.g. a per-test field on every such test). That was rejected here because it means touching ~100 tests across several classes, for a theoretical edge case (e.g. `-Xmx4m` or an experimental aggressive GC) that does not reflect the CI configuration. If desired, that stronger approach can be applied on top.

### Why a centralized extension fix (instead of editing the tests)

| | Extension pin (this PR) | Per-test keep-alive reference |
|---|---|---|
| Production change | none | none |
| Files touched | **1** (the extension) | 3–4 classes + ~100 call sites |
| Risk of breaking the lifecycle battery | minimal | high (massive churn) |
| Guarantee | empirically eliminates the flake (race shrunk, not closed) | mathematically hard (ref held from start) |

The pin **does not mask bugs**: `expectDirtyStack = false` tests still fail if they leave the stack dirty, and production behavior is untouched.

## Added diagnostic / guarantee test

`MeterThreadLocalWeakReferenceGcTest` (test-only):

- **Reproduces the non-determinism deterministically** by driving the GC (weak canary + allocation pressure): an unreferenced started `Meter` is lost from the stack, while a strongly referenced one survives — isolating the `WeakReference` as the sole cause.
- **Proves the design satisfies the production requirement**: a forgotten `Meter` is reclaimed (**no memory leak**), logs an inconsistency warning via `finalize()` (`"Meter never stopped..."`), and the stack **self-heals** back to `"???"`. This would fail if the `WeakReference` were ever removed.

## Verification

Under aggressive GC (`-Xmx64m -XX:+UseSerialGC`), which reliably surfaces the race:

| Condition | Without the fix | With the fix |
|---|---|---|
| Flaky classes | **1 of 3 runs failed** (message identical to CI) | **green across repeated runs** |
| Full suite | — | **3002 tests, 0 failures** |

Reproducing the exact original failure without the fix, and stability with it under the same adverse conditions, confirms the fix addresses the real root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
