### PR TITLE
Replace Meter.finalize() with a forward-compatible leak detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ try {
 }
 ```
 
+## Leak detection (forgotten meters)
+
+A `Meter` that is `start()`-ed but never explicitly terminated (`ok()`, `reject()`, `fail()`, or `close()`) indicates inconsistent API usage. *slf4j-toys* detects such a **forgotten meter** and logs an `ERROR` message (marker `INVALID_ARGUMENT`) when the meter is garbage-collected:
+
+```
+ERROR ... Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=...
+```
+
+Detection is purely garbage-collection driven and allocation-light (it reuses the meter's thread-local stack reference, so a tracked meter costs no extra object). It installs **no JVM shutdown hook and no background thread**, so it is safe inside servlet containers and application servers — a forgotten meter that is never collected before the JVM exits is simply not reported (it does not leak memory, as it is only weakly referenced).
+
+> **Note:** This replaces the previous `Object.finalize()`-based detection, which is deprecated for removal (JEP 421). There is no API change for callers.
+
+### Configuration
+
+| Property | System property | Default | Description |
+|---|---|---|---|
+| `MeterConfig.detectLeaks` | `slf4jtoys.meter.detect.leaks` | `true` | Enables forgotten-meter detection. Acts as a runtime kill switch: set to `false` and meters started afterwards are not tracked, and reports already pending are suppressed. Disable it in tests that intentionally leave meters open, or to remove the (already minimal) tracking overhead. |
+
+```java
+// Disable globally at startup, e.g. in tests:
+MeterConfig.detectLeaks = false;
+```
+```properties
+# Or via system property:
+-Dslf4jtoys.meter.detect.leaks=false
+```
+
 ## Installation
 
 *slf4j-toys* is available from the [Maven Central repository](https://search.maven.org/artifact/org.usefultoys/slf4j-toys/1.9.0/jar).

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -25,7 +25,6 @@ import org.usefultoys.slf4j.internal.SystemMetrics;
 import org.usefultoys.slf4j.internal.TimeSource;
 
 import java.io.Closeable;
-import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -89,21 +88,18 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
     private transient long lastProgressIteration = 0;
 
     /**
-     * Tracks the `Meter` instance most recently started on the current thread.
+     * Tracks the `Meter` instance most recently started on the current thread. Each entry is a
+     * {@link MeterLeakDetector.MeterReference}, which is a weak reference to the meter that doubles as the
+     * leak-detection handle; the entries are chained via {@code previousInstance} to form the per-thread stack.
      */
-    private static final ThreadLocal<WeakReference<Meter>> localThreadInstance = new ThreadLocal<>();
-    /**
-     * Stores a weak reference to the `Meter` instance that was current before this `Meter` became the current one.
-     * These references form a linked list representing a stack of `Meter` instances.
-     */
-    private WeakReference<Meter> previousInstance;
+    private static final ThreadLocal<MeterLeakDetector.MeterReference> localThreadInstance = new ThreadLocal<>();
 
     /**
-     * Registration handle with the {@link MeterLeakDetector}, obtained on {@link #start()} when leak detection is
-     * enabled ({@link MeterConfig#detectLeaks}) and the category is known. It is {@code null} otherwise. The handle is
-     * passed back to the detector on every explicit termination so that this `Meter` is not reported as a leak.
+     * This `Meter`'s own node in the thread-local stack, created on {@link #start()}. It is also the leak-detection
+     * handle when leak detection is enabled. Held so that termination can pop the stack and untrack the meter. It is
+     * {@code null} before {@code start()} and after termination.
      */
-    private transient MeterLeakDetector.MeterReference leakRef;
+    private transient MeterLeakDetector.MeterReference selfRef;
 
     /**
      * Creates a new `Meter` for an operation belonging to the category derived from the logger's name.
@@ -192,7 +188,7 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * @return The current `Meter` instance, or a dummy `Meter` if none is active on the current thread.
      */
     public static Meter getCurrentInstance() {
-        final WeakReference<Meter> ref = localThreadInstance.get();
+        final MeterLeakDetector.MeterReference ref = localThreadInstance.get();
         final Meter current = ref == null ? null : ref.get();
         /* Return dummy meter if no active meter on current thread */
         if (current == null) {
@@ -353,16 +349,12 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 return this;
             }
 
-            previousInstance = localThreadInstance.get();
-            localThreadInstance.set(new WeakReference<>(this));
+            /* Push this Meter onto the thread-local stack. The single reference also serves as the leak-detection
+               handle when enabled; track() applies the detectLeaks / "???" exclusion internally. */
+            selfRef = MeterLeakDetector.track(this, localThreadInstance.get());
+            localThreadInstance.set(selfRef);
 
             lastProgressTime = startTime = collectCurrentTime();
-
-            /* Register with the leak detector so a started-but-never-stopped Meter is reported when garbage-collected.
-               Excludes the dummy "???" Meter, matching the predicate of the former finalize() mechanism. */
-            if (MeterConfig.detectLeaks && !UNKNOWN_LOGGER_NAME.equals(getCategory())) {
-                leakRef = MeterLeakDetector.register(this);
-            }
 
             if (messageLogger.isDebugEnabled()) {
                 SystemMetrics.getInstance().collectRuntimeStatus(this);
@@ -514,9 +506,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             if (pathId != null) {
                 okPath = toPath(pathId, true);
             }
-            localThreadInstance.set(previousInstance);
-            MeterLeakDetector.deregister(leakRef);
-            leakRef = null;
+            localThreadInstance.set(MeterLeakDetector.untrack(selfRef));
+            selfRef = null;
 
             if (messageLogger.isWarnEnabled()) { // Check warn enabled to cover info as well
                 SystemMetrics.getInstance().collectRuntimeStatus(this);
@@ -553,7 +544,7 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * @return {@code true} if this `Meter` is not the current instance, {@code false} otherwise.
      */
     boolean checkCurrentInstance() {
-        final WeakReference<Meter> ref = localThreadInstance.get();
+        final MeterLeakDetector.MeterReference ref = localThreadInstance.get();
         /* Returns true if this meter is NOT the current one (inverse logic for validation purposes) */
         return ref == null || ref.get() != this;
     }
@@ -632,9 +623,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             failPath = null;
             failMessage = null;
             okPath = null;
-            localThreadInstance.set(previousInstance);
-            MeterLeakDetector.deregister(leakRef);
-            leakRef = null;
+            localThreadInstance.set(MeterLeakDetector.untrack(selfRef));
+            selfRef = null;
             rejectPath = toPath(cause, true);
 
             if (messageLogger.isInfoEnabled()) {
@@ -680,9 +670,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             }
             rejectPath = null;
             okPath = null;
-            localThreadInstance.set(previousInstance);
-            MeterLeakDetector.deregister(leakRef);
-            leakRef = null;
+            localThreadInstance.set(MeterLeakDetector.untrack(selfRef));
+            selfRef = null;
             failPath = toPath(cause, false);
             /* Extract failure message from Throwable if applicable */
             if (cause instanceof Throwable) {
@@ -733,9 +722,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             }
             rejectPath = null;
             okPath = null;
-            localThreadInstance.set(previousInstance);
-            MeterLeakDetector.deregister(leakRef);
-            leakRef = null;
+            localThreadInstance.set(MeterLeakDetector.untrack(selfRef));
+            selfRef = null;
             failPath = FAIL_PATH_TRY_WITH_RESOURCES;
 
             if (messageLogger.isErrorEnabled()) {

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -52,7 +52,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @see MeterConfig
  * @see Markers
  */
-@SuppressWarnings({"OverlyBroadCatchBlock", "FinalizeDeclaration"})
+@SuppressWarnings("OverlyBroadCatchBlock")
 public class Meter extends MeterData implements MeterContext<Meter>, MeterExecutor<Meter>, Closeable {
 
     /**
@@ -97,6 +97,13 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * These references form a linked list representing a stack of `Meter` instances.
      */
     private WeakReference<Meter> previousInstance;
+
+    /**
+     * Registration handle with the {@link MeterLeakDetector}, obtained on {@link #start()} when leak detection is
+     * enabled ({@link MeterConfig#detectLeaks}) and the category is known. It is {@code null} otherwise. The handle is
+     * passed back to the detector on every explicit termination so that this `Meter` is not reported as a leak.
+     */
+    private transient MeterLeakDetector.MeterReference leakRef;
 
     /**
      * Creates a new `Meter` for an operation belonging to the category derived from the logger's name.
@@ -351,6 +358,12 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
 
             lastProgressTime = startTime = collectCurrentTime();
 
+            /* Register with the leak detector so a started-but-never-stopped Meter is reported when garbage-collected.
+               Excludes the dummy "???" Meter, matching the predicate of the former finalize() mechanism. */
+            if (MeterConfig.detectLeaks && !UNKNOWN_LOGGER_NAME.equals(getCategory())) {
+                leakRef = MeterLeakDetector.register(this);
+            }
+
             if (messageLogger.isDebugEnabled()) {
                 SystemMetrics.getInstance().collectRuntimeStatus(this);
                 SystemMetrics.getInstance().collectPlatformStatus(this);
@@ -502,6 +515,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 okPath = toPath(pathId, true);
             }
             localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
 
             if (messageLogger.isWarnEnabled()) { // Check warn enabled to cover info as well
                 SystemMetrics.getInstance().collectRuntimeStatus(this);
@@ -618,6 +633,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             failMessage = null;
             okPath = null;
             localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
             rejectPath = toPath(cause, true);
 
             if (messageLogger.isInfoEnabled()) {
@@ -664,6 +681,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             rejectPath = null;
             okPath = null;
             localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
             failPath = toPath(cause, false);
             /* Extract failure message from Throwable if applicable */
             if (cause instanceof Throwable) {
@@ -693,22 +712,6 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
     // ========================================================================
 
     /**
-     * Overrides the default `finalize()` method to detect `Meter` instances that were started but never explicitly
-     * stopped. If an unstopped `Meter` is garbage-collected, an error message is logged to indicate inconsistent API
-     * usage.
-     *
-     * @throws Throwable if an error occurs during finalization.
-     */
-    @SuppressWarnings("removal")
-    @Override
-    protected void finalize() throws Throwable {
-        MeterValidator.validateFinalize(this);
-        super.finalize();
-    }
-
-    // ========================================================================
-
-    /**
      * Implements the {@link Closeable} interface. If the `Meter` has not been explicitly stopped (via `ok()`,
      * `reject()`, or `fail()`), this method automatically marks the operation as {@code FAIL} with the path
      * {@code "try-with-resources"}. This ensures that no operation goes untracked when used in a `try-with-resources`
@@ -731,6 +734,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             rejectPath = null;
             okPath = null;
             localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
             failPath = FAIL_PATH_TRY_WITH_RESOURCES;
 
             if (messageLogger.isErrorEnabled()) {

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -64,6 +64,8 @@ public class MeterConfig {
     public final String PROP_PRINT_STATUS = "slf4jtoys.meter.print.status";
     /** System property key for enabling/disabling the forgotten-meter leak detector. */
     public final String PROP_DETECT_LEAKS = "slf4jtoys.meter.detect.leaks";
+    /** System property key for enabling/disabling the final leak sweep on JVM shutdown. */
+    public final String PROP_REPORT_LEAKS_ON_SHUTDOWN = "slf4jtoys.meter.report.leaks.on.shutdown";
 
     static {
         init();
@@ -134,6 +136,22 @@ public class MeterConfig {
     public boolean detectLeaks;
 
     /**
+     * Whether the {@link Meter} leak detector performs a final sweep on JVM shutdown.
+     * <p>
+     * The runtime detector ({@link #detectLeaks}) only reports a forgotten {@link Meter} once it has been
+     * garbage-collected and another meter is started. When this flag is {@code true}, a JVM shutdown hook is
+     * installed (lazily, on the first started meter) that reports every meter still started-but-never-stopped at
+     * shutdown — including those the garbage collector never reclaimed during the application's life.
+     * <p>
+     * This is opt-in because it installs a shutdown hook and may report meters that were legitimately still in
+     * progress at shutdown. It has no effect when {@link #detectLeaks} is {@code false}.
+     * <p>
+     * Value is read from system property {@code slf4jtoys.meter.report.leaks.on.shutdown}, defaulting to {@code false}.
+     * Can be assigned a new value at runtime.
+     */
+    public boolean reportLeaksOnShutdown;
+
+    /**
      * A prefix added to the logger name used for machine-parsable data messages.
      * <p>
      * By default, encoded and human-readable messages are written to the same logger. Setting a prefix allows
@@ -197,6 +215,7 @@ public class MeterConfig {
         printLoad = ConfigParser.getProperty(PROP_PRINT_LOAD, false);
         printMemory = ConfigParser.getProperty(PROP_PRINT_MEMORY, false);
         detectLeaks = ConfigParser.getProperty(PROP_DETECT_LEAKS, true);
+        reportLeaksOnShutdown = ConfigParser.getProperty(PROP_REPORT_LEAKS_ON_SHUTDOWN, false);
         dataPrefix = ConfigParser.getProperty(PROP_DATA_PREFIX, "");
         dataSuffix = ConfigParser.getProperty(PROP_DATA_SUFFIX, "");
         messagePrefix = ConfigParser.getProperty(PROP_MESSAGE_PREFIX, "");
@@ -215,6 +234,7 @@ public class MeterConfig {
         System.clearProperty(PROP_PRINT_LOAD);
         System.clearProperty(PROP_PRINT_MEMORY);
         System.clearProperty(PROP_DETECT_LEAKS);
+        System.clearProperty(PROP_REPORT_LEAKS_ON_SHUTDOWN);
         System.clearProperty(PROP_DATA_PREFIX);
         System.clearProperty(PROP_DATA_SUFFIX);
         System.clearProperty(PROP_MESSAGE_PREFIX);

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -62,6 +62,8 @@ public class MeterConfig {
     public final String PROP_PRINT_POSITION = "slf4jtoys.meter.print.position";
     /** System property key for enabling/disabling status printing in readable messages. */
     public final String PROP_PRINT_STATUS = "slf4jtoys.meter.print.status";
+    /** System property key for enabling/disabling the forgotten-meter leak detector. */
+    public final String PROP_DETECT_LEAKS = "slf4jtoys.meter.detect.leaks";
 
     static {
         init();
@@ -115,6 +117,21 @@ public class MeterConfig {
      * Can be assigned a new value at runtime.
      */
     public boolean printMemory;
+
+    /**
+     * Whether the {@link Meter} activates the forgotten-meter leak detector.
+     * <p>
+     * When {@code true}, a {@link Meter} that is started but never explicitly stopped ({@code ok()},
+     * {@code reject()}, {@code fail()}, or {@code close()}) will emit an error log message when it
+     * becomes eligible for garbage collection.
+     * <p>
+     * Disable this flag in test environments where meters are intentionally left open, or when the
+     * overhead of registering each started meter is undesirable.
+     * <p>
+     * Value is read from system property {@code slf4jtoys.meter.detect.leaks}, defaulting to {@code true}.
+     * Can be assigned a new value at runtime.
+     */
+    public boolean detectLeaks;
 
     /**
      * A prefix added to the logger name used for machine-parsable data messages.
@@ -179,6 +196,7 @@ public class MeterConfig {
         printPosition = ConfigParser.getProperty(PROP_PRINT_POSITION, false);
         printLoad = ConfigParser.getProperty(PROP_PRINT_LOAD, false);
         printMemory = ConfigParser.getProperty(PROP_PRINT_MEMORY, false);
+        detectLeaks = ConfigParser.getProperty(PROP_DETECT_LEAKS, true);
         dataPrefix = ConfigParser.getProperty(PROP_DATA_PREFIX, "");
         dataSuffix = ConfigParser.getProperty(PROP_DATA_SUFFIX, "");
         messagePrefix = ConfigParser.getProperty(PROP_MESSAGE_PREFIX, "");
@@ -196,6 +214,7 @@ public class MeterConfig {
         System.clearProperty(PROP_PRINT_POSITION);
         System.clearProperty(PROP_PRINT_LOAD);
         System.clearProperty(PROP_PRINT_MEMORY);
+        System.clearProperty(PROP_DETECT_LEAKS);
         System.clearProperty(PROP_DATA_PREFIX);
         System.clearProperty(PROP_DATA_SUFFIX);
         System.clearProperty(PROP_MESSAGE_PREFIX);

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -64,8 +64,6 @@ public class MeterConfig {
     public final String PROP_PRINT_STATUS = "slf4jtoys.meter.print.status";
     /** System property key for enabling/disabling the forgotten-meter leak detector. */
     public final String PROP_DETECT_LEAKS = "slf4jtoys.meter.detect.leaks";
-    /** System property key for enabling/disabling the final leak sweep on JVM shutdown. */
-    public final String PROP_REPORT_LEAKS_ON_SHUTDOWN = "slf4jtoys.meter.report.leaks.on.shutdown";
 
     static {
         init();
@@ -130,28 +128,12 @@ public class MeterConfig {
      * Disable this flag in test environments where meters are intentionally left open, or when the
      * overhead of registering each started meter is undesirable. The flag gates both ends: a meter started while it
      * is {@code false} is never tracked, and turning it {@code false} at runtime also suppresses reports for meters
-     * already tracked (including the shutdown sweep), so it works as a runtime kill switch.
+     * already tracked, so it works as a runtime kill switch.
      * <p>
      * Value is read from system property {@code slf4jtoys.meter.detect.leaks}, defaulting to {@code true}.
      * Can be assigned a new value at runtime.
      */
     public boolean detectLeaks;
-
-    /**
-     * Whether the {@link Meter} leak detector performs a final sweep on JVM shutdown.
-     * <p>
-     * The runtime detector ({@link #detectLeaks}) only reports a forgotten {@link Meter} once it has been
-     * garbage-collected and another meter is started. When this flag is {@code true}, a JVM shutdown hook is
-     * installed (lazily, on the first started meter) that reports every meter still started-but-never-stopped at
-     * shutdown — including those the garbage collector never reclaimed during the application's life.
-     * <p>
-     * This is opt-in because it installs a shutdown hook and may report meters that were legitimately still in
-     * progress at shutdown. It has no effect when {@link #detectLeaks} is {@code false}.
-     * <p>
-     * Value is read from system property {@code slf4jtoys.meter.report.leaks.on.shutdown}, defaulting to {@code false}.
-     * Can be assigned a new value at runtime.
-     */
-    public boolean reportLeaksOnShutdown;
 
     /**
      * A prefix added to the logger name used for machine-parsable data messages.
@@ -217,7 +199,6 @@ public class MeterConfig {
         printLoad = ConfigParser.getProperty(PROP_PRINT_LOAD, false);
         printMemory = ConfigParser.getProperty(PROP_PRINT_MEMORY, false);
         detectLeaks = ConfigParser.getProperty(PROP_DETECT_LEAKS, true);
-        reportLeaksOnShutdown = ConfigParser.getProperty(PROP_REPORT_LEAKS_ON_SHUTDOWN, false);
         dataPrefix = ConfigParser.getProperty(PROP_DATA_PREFIX, "");
         dataSuffix = ConfigParser.getProperty(PROP_DATA_SUFFIX, "");
         messagePrefix = ConfigParser.getProperty(PROP_MESSAGE_PREFIX, "");
@@ -236,7 +217,6 @@ public class MeterConfig {
         System.clearProperty(PROP_PRINT_LOAD);
         System.clearProperty(PROP_PRINT_MEMORY);
         System.clearProperty(PROP_DETECT_LEAKS);
-        System.clearProperty(PROP_REPORT_LEAKS_ON_SHUTDOWN);
         System.clearProperty(PROP_DATA_PREFIX);
         System.clearProperty(PROP_DATA_SUFFIX);
         System.clearProperty(PROP_MESSAGE_PREFIX);

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -124,11 +124,13 @@ public class MeterConfig {
      * Whether the {@link Meter} activates the forgotten-meter leak detector.
      * <p>
      * When {@code true}, a {@link Meter} that is started but never explicitly stopped ({@code ok()},
-     * {@code reject()}, {@code fail()}, or {@code close()}) will emit an error log message when it
+     * {@code reject()}, {@code fail()}, or {@code close()}) will emit an {@code error}-level log message when it
      * becomes eligible for garbage collection.
      * <p>
      * Disable this flag in test environments where meters are intentionally left open, or when the
-     * overhead of registering each started meter is undesirable.
+     * overhead of registering each started meter is undesirable. The flag gates both ends: a meter started while it
+     * is {@code false} is never tracked, and turning it {@code false} at runtime also suppresses reports for meters
+     * already tracked (including the shutdown sweep), so it works as a runtime kill switch.
      * <p>
      * Value is read from system property {@code slf4jtoys.meter.detect.leaks}, defaulting to {@code true}.
      * Can be assigned a new value at runtime.

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.slf4j.Logger;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+
+/**
+ * Forward-compatible detector for {@link Meter} instances that were started but never explicitly stopped
+ * (via {@code ok()}, {@code reject()}, {@code fail()} or {@code close()}).
+ * <p>
+ * This is the replacement for the deprecated {@link Object#finalize()} mechanism. It relies on
+ * {@link PhantomReference} plus a {@link ReferenceQueue} — an API available on every Java version since Java 2 —
+ * so it keeps working on Java 8 through future releases where finalization is removed.
+ * <p>
+ * <b>Design — at most one extra object per started meter:</b> each started meter that opts in registers exactly one
+ * {@link MeterReference}. That reference <em>is</em> the node of an intrusive doubly-linked list (it carries its own
+ * {@code prev}/{@code next} pointers), so no separate container node is allocated — unlike a {@code Set} or
+ * {@code Map} backed registry. This mirrors what {@code java.lang.ref.Cleaner} does internally.
+ * <p>
+ * <b>Draining strategy — no background thread:</b> the {@link ReferenceQueue} is drained opportunistically from
+ * {@link #register(Meter)}, i.e. on the thread that starts the next meter. A forgotten meter is therefore reported
+ * the next time any meter is started, with no library-owned daemon thread and no risk of pinning a web application
+ * class loader in a servlet container.
+ * <p>
+ * <b>Predicate equivalence:</b> a meter is registered only from {@code start()} (so {@code startTime != 0} is implied)
+ * and is deregistered on every explicit termination. Therefore a reference that the garbage collector enqueues
+ * <em>while still registered</em> is, by definition, a meter that was started and never stopped — exactly the
+ * predicate the former {@code finalize()} path checked. The {@code UNKNOWN_LOGGER_NAME} exclusion and the
+ * {@link MeterConfig#detectLeaks} toggle are enforced by the caller, keeping this class a pure mechanism.
+ *
+ * @author Daniel Felix Ferber
+ * @see Meter
+ * @see MeterConfig#detectLeaks
+ */
+final class MeterLeakDetector {
+
+    private MeterLeakDetector() {
+        // Utility holder, not instantiable.
+    }
+
+    /** Queue onto which the garbage collector enqueues references whose meters became unreachable. */
+    private static final ReferenceQueue<Meter> QUEUE = new ReferenceQueue<>();
+
+    /** Guards the intrusive linked list rooted at {@link #head}. */
+    private static final Object LOCK = new Object();
+
+    /** Head of the intrusive doubly-linked list of currently registered references; {@code null} when empty. */
+    private static MeterReference head;
+
+    /**
+     * A {@link PhantomReference} to a started {@link Meter} that doubles as the node of the intrusive linked list.
+     * It snapshots only the immutable data required to report a leak ({@code fullID}) plus the message logger
+     * (an SLF4J singleton, safe to retain), because the referent {@link Meter} is already collected by the time the
+     * leak is reported.
+     */
+    static final class MeterReference extends PhantomReference<Meter> {
+        private final String fullID;
+        private final Logger messageLogger;
+        /** Intrusive list links; guarded by {@link MeterLeakDetector#LOCK}. */
+        private MeterReference prev;
+        private MeterReference next;
+        /** {@code true} while this reference is linked in the list; guarded by {@link MeterLeakDetector#LOCK}. */
+        private boolean registered;
+
+        MeterReference(final Meter meter, final ReferenceQueue<Meter> queue) {
+            super(meter, queue);
+            this.fullID = meter.getFullID();
+            this.messageLogger = meter.getMessageLogger();
+        }
+
+        /**
+         * Emits the forgotten-meter error, byte-for-byte equivalent to the former {@code MeterValidator.validateFinalize}.
+         */
+        void reportLeak() {
+            messageLogger.error(Markers.INVALID_ARGUMENT, "{}; id={}",
+                    "Meter never stopped, must remember to call ok/reject/fail/success() on each started one",
+                    fullID);
+        }
+    }
+
+    /**
+     * Registers a started meter for leak detection and drains any pending leaks first.
+     * The returned reference must be handed back to {@link #deregister(MeterReference)} when the meter is stopped.
+     *
+     * @param meter the meter that has just started; must not be {@code null}.
+     * @return the registration handle to keep on the meter and pass to {@link #deregister(MeterReference)}.
+     */
+    static MeterReference register(final Meter meter) {
+        drain();
+        final MeterReference ref = new MeterReference(meter, QUEUE);
+        synchronized (LOCK) {
+            ref.next = head;
+            if (head != null) {
+                head.prev = ref;
+            }
+            head = ref;
+            ref.registered = true;
+        }
+        return ref;
+    }
+
+    /**
+     * Deregisters a meter that was stopped explicitly, so its eventual collection is not reported as a leak.
+     * Idempotent and {@code null}-safe. Clearing the reference also prevents the garbage collector from ever
+     * enqueueing it, since at this point the referent meter is still strongly reachable.
+     *
+     * @param ref the handle returned by {@link #register(Meter)}, or {@code null}.
+     */
+    static void deregister(final MeterReference ref) {
+        if (ref == null) {
+            return;
+        }
+        synchronized (LOCK) {
+            unlink(ref);
+        }
+        ref.clear();
+    }
+
+    /**
+     * Drains the reference queue, reporting every meter that was collected while still registered.
+     * Safe to call from any thread; invoked opportunistically by {@link #register(Meter)}.
+     */
+    static void drain() {
+        Reference<? extends Meter> r;
+        while ((r = QUEUE.poll()) != null) {
+            final MeterReference ref = (MeterReference) r;
+            final boolean wasRegistered;
+            synchronized (LOCK) {
+                wasRegistered = ref.registered;
+                unlink(ref);
+            }
+            if (wasRegistered) {
+                ref.reportLeak();
+            }
+        }
+    }
+
+    /**
+     * Unlinks a reference from the intrusive list. Caller must hold {@link #LOCK}. Idempotent.
+     */
+    private static void unlink(final MeterReference ref) {
+        if (!ref.registered) {
+            return;
+        }
+        if (ref.prev != null) {
+            ref.prev.next = ref.next;
+        } else {
+            head = ref.next;
+        }
+        if (ref.next != null) {
+            ref.next.prev = ref.prev;
+        }
+        ref.prev = null;
+        ref.next = null;
+        ref.registered = false;
+    }
+
+    /**
+     * Number of currently registered references. For tests only.
+     */
+    static int trackedCount() {
+        int count = 0;
+        synchronized (LOCK) {
+            for (MeterReference ref = head; ref != null; ref = ref.next) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
@@ -17,9 +17,9 @@ package org.usefultoys.slf4j.meter;
 
 import org.slf4j.Logger;
 
-import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -27,29 +27,37 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * (via {@code ok()}, {@code reject()}, {@code fail()} or {@code close()}).
  * <p>
  * This is the replacement for the deprecated {@link Object#finalize()} mechanism. It relies on
- * {@link PhantomReference} plus a {@link ReferenceQueue} — an API available on every Java version since Java 2 —
+ * {@link WeakReference} plus a {@link ReferenceQueue} — an API available on every Java version since Java 2 —
  * so it keeps working on Java 8 through future releases where finalization is removed.
  * <p>
- * <b>Design — at most one extra object per started meter:</b> each started meter that opts in registers exactly one
- * {@link MeterReference}. That reference <em>is</em> the node of an intrusive doubly-linked list (it carries its own
- * {@code prev}/{@code next} pointers), so no separate container node is allocated — unlike a {@code Set} or
- * {@code Map} backed registry. This mirrors what {@code java.lang.ref.Cleaner} does internally.
+ * <b>Design — a single reference object per started meter:</b> {@link MeterReference} is, at the same time, the
+ * node of the {@link Meter} thread-local stack (its {@link WeakReference#get()} returns the current meter, or
+ * {@code null} once it is collected) and, when leak detection is enabled, the handle the garbage collector enqueues
+ * on collection. It also <em>is</em> the node of the intrusive doubly-linked registry (it carries its own
+ * {@code prev}/{@code next} pointers), so no separate container node is allocated. Unifying the stack reference and
+ * the leak-detection reference keeps allocation at one auxiliary object per started meter — the same cost the
+ * thread-local stack already paid before leak detection existed.
+ * <p>
+ * A {@link WeakReference} (rather than a {@code PhantomReference}) is required because the stack must be able to
+ * retrieve the live meter; it is also a better fit, since the referent is reclaimed as soon as it becomes weakly
+ * reachable and {@code reportLeak()} works from an immutable snapshot rather than the (already cleared) referent.
  * <p>
  * <b>Draining strategy — no background thread:</b> the {@link ReferenceQueue} is drained opportunistically from
- * {@link #register(Meter)}, i.e. on the thread that starts the next meter. A forgotten meter is therefore reported
- * the next time any meter is started, with no library-owned daemon thread and no risk of pinning a web application
- * class loader in a servlet container.
+ * {@link #track(Meter, MeterReference)}, i.e. on the thread that starts the next meter. A forgotten meter is therefore
+ * reported the next time any meter is started, with no library-owned daemon thread and no risk of pinning a web
+ * application class loader in a servlet container.
  * <p>
- * <b>Predicate equivalence:</b> a meter is registered only from {@code start()} (so {@code startTime != 0} is implied)
- * and is deregistered on every explicit termination. Therefore a reference that the garbage collector enqueues
+ * <b>Predicate equivalence:</b> a meter is leak-tracked only from {@code start()} (so {@code startTime != 0} is
+ * implied) and is untracked on every explicit termination. Therefore a reference that the garbage collector enqueues
  * <em>while still registered</em> is, by definition, a meter that was started and never stopped — exactly the
  * predicate the former {@code finalize()} path checked. The {@code UNKNOWN_LOGGER_NAME} exclusion and the
- * {@link MeterConfig#detectLeaks} toggle are enforced by the caller, keeping this class a pure mechanism.
+ * {@link MeterConfig#detectLeaks} toggle are applied in {@link #track(Meter, MeterReference)}; when leak detection is
+ * off, the reference is still created to serve as the stack node, but is neither queued nor registered.
  * <p>
  * <b>Tail draining on shutdown:</b> the opportunistic drain only reports meters the garbage collector has already
  * reclaimed. Meters that are forgotten but never collected during the application's life would otherwise go
  * unreported. When {@link MeterConfig#reportLeaksOnShutdown} is enabled, a JVM shutdown hook is installed lazily (on
- * the first registration) that runs {@link #reportRemainingLeaks()}, reporting every meter still registered at
+ * the first tracked meter) that runs {@link #reportRemainingLeaks()}, reporting every meter still registered at
  * shutdown.
  *
  * @author Daniel Felix Ferber
@@ -79,20 +87,32 @@ final class MeterLeakDetector {
     private static volatile Thread shutdownHook;
 
     /**
-     * A {@link PhantomReference} to a started {@link Meter} that doubles as the node of the intrusive linked list.
-     * It snapshots only the immutable data required to report a leak ({@code fullID}) plus the message logger
-     * (an SLF4J singleton, safe to retain), because the referent {@link Meter} is already collected by the time the
-     * leak is reported.
+     * A {@link WeakReference} to a started {@link Meter} that doubles as both the node of the thread-local stack and,
+     * when leak detection is enabled, the node of the intrusive leak registry. When leak-detecting it snapshots the
+     * immutable data required to report a leak ({@code fullID}) plus the message logger (an SLF4J singleton, safe to
+     * retain), because the referent {@link Meter} is already collected by the time the leak is reported.
      */
-    static final class MeterReference extends PhantomReference<Meter> {
+    static final class MeterReference extends WeakReference<Meter> {
+        /** Leak-report snapshot; {@code null} when this reference is a plain (non-detecting) stack node. */
         private final String fullID;
+        /** Leak-report logger; {@code null} when this reference is a plain (non-detecting) stack node. */
         private final Logger messageLogger;
-        /** Intrusive list links; guarded by {@link MeterLeakDetector#LOCK}. */
+        /** Previous reference on the per-thread stack; accessed only by the owning thread, so no lock is needed. */
+        private MeterReference previousInstance;
+        /** Intrusive registry links; guarded by {@link MeterLeakDetector#LOCK}. */
         private MeterReference prev;
         private MeterReference next;
-        /** {@code true} while this reference is linked in the list; guarded by {@link MeterLeakDetector#LOCK}. */
+        /** {@code true} while this reference is linked in the registry; guarded by {@link MeterLeakDetector#LOCK}. */
         private boolean registered;
 
+        /** Creates a plain stack node that is not leak-detecting (no queue, no snapshot). */
+        MeterReference(final Meter meter) {
+            super(meter);
+            this.fullID = null;
+            this.messageLogger = null;
+        }
+
+        /** Creates a leak-detecting stack node: enqueued on collection and carrying a leak snapshot. */
         MeterReference(final Meter meter, final ReferenceQueue<Meter> queue) {
             super(meter, queue);
             this.fullID = meter.getFullID();
@@ -110,18 +130,28 @@ final class MeterLeakDetector {
     }
 
     /**
-     * Registers a started meter for leak detection and drains any pending leaks first.
-     * The returned reference must be handed back to {@link #deregister(MeterReference)} when the meter is stopped.
+     * Creates the stack-node reference for a meter that has just started, chaining it onto {@code previous}, and — when
+     * {@link MeterConfig#detectLeaks} is enabled and the category is known — also registers it for leak detection and
+     * drains any pending leaks first.
      *
-     * @param meter the meter that has just started; must not be {@code null}.
-     * @return the registration handle to keep on the meter and pass to {@link #deregister(MeterReference)}.
+     * @param meter    the meter that has just started; must not be {@code null}.
+     * @param previous the reference currently on top of the thread-local stack, or {@code null}.
+     * @return the new reference to push onto the stack and keep on the meter for {@link #untrack(MeterReference)}.
      */
-    static MeterReference register(final Meter meter) {
+    static MeterReference track(final Meter meter, final MeterReference previous) {
+        final boolean detect = MeterConfig.detectLeaks
+                && !Meter.UNKNOWN_LOGGER_NAME.equals(meter.getCategory());
+        if (!detect) {
+            final MeterReference ref = new MeterReference(meter);
+            ref.previousInstance = previous;
+            return ref;
+        }
         drain();
         if (MeterConfig.reportLeaksOnShutdown) {
             installShutdownHookOnce();
         }
         final MeterReference ref = new MeterReference(meter, QUEUE);
+        ref.previousInstance = previous;
         synchronized (LOCK) {
             ref.next = head;
             if (head != null) {
@@ -134,25 +164,30 @@ final class MeterLeakDetector {
     }
 
     /**
-     * Deregisters a meter that was stopped explicitly, so its eventual collection is not reported as a leak.
-     * Idempotent and {@code null}-safe. Clearing the reference also prevents the garbage collector from ever
-     * enqueueing it, since at this point the referent meter is still strongly reachable.
+     * Untracks a meter that was stopped explicitly, so its eventual collection is not reported as a leak, and returns
+     * the reference to restore as the new top of the thread-local stack. Idempotent and {@code null}-safe.
+     * <p>
+     * The reference is intentionally <em>not</em> cleared: a stopped reference may still be reachable through the
+     * {@code previousInstance} of a meter that was (mistakenly) started on top of it, and clearing would corrupt that
+     * chain. A stopped-then-collected reference that is later enqueued is harmlessly ignored by {@link #drain()},
+     * because {@link #unlink(MeterReference)} has already marked it unregistered.
      *
-     * @param ref the handle returned by {@link #register(Meter)}, or {@code null}.
+     * @param ref the reference returned by {@link #track(Meter, MeterReference)}, or {@code null}.
+     * @return the previous reference to restore as the stack top, or {@code null}.
      */
-    static void deregister(final MeterReference ref) {
+    static MeterReference untrack(final MeterReference ref) {
         if (ref == null) {
-            return;
+            return null;
         }
         synchronized (LOCK) {
             unlink(ref);
         }
-        ref.clear();
+        return ref.previousInstance;
     }
 
     /**
      * Drains the reference queue, reporting every meter that was collected while still registered.
-     * Safe to call from any thread; invoked opportunistically by {@link #register(Meter)}.
+     * Safe to call from any thread; invoked opportunistically by {@link #track(Meter, MeterReference)}.
      */
     static void drain() {
         Reference<? extends Meter> r;
@@ -192,7 +227,6 @@ final class MeterLeakDetector {
             final MeterReference next = ref.next;
             ref.next = null;
             ref.reportLeak();
-            ref.clear();
             ref = next;
         }
     }
@@ -223,7 +257,8 @@ final class MeterLeakDetector {
     }
 
     /**
-     * Unlinks a reference from the intrusive list. Caller must hold {@link #LOCK}. Idempotent.
+     * Unlinks a reference from the intrusive registry. Caller must hold {@link #LOCK}. Idempotent. Does not touch the
+     * {@code previousInstance} stack link.
      */
     private static void unlink(final MeterReference ref) {
         if (!ref.registered) {

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Forward-compatible detector for {@link Meter} instances that were started but never explicitly stopped
@@ -54,21 +53,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@link MeterConfig#detectLeaks} toggle are applied in {@link #track(Meter, MeterReference)}; when leak detection is
  * off, the reference is still created to serve as the stack node, but is neither queued nor registered.
  * <p>
- * <b>{@code detectLeaks} also gates emission at report time:</b> {@link #drain()} and {@link #reportRemainingLeaks()}
- * re-read {@link MeterConfig#detectLeaks} and stay silent when it is {@code false}, still cleaning up the registry.
- * So turning the toggle off at runtime suppresses pending leak reports for meters that were already registered, not
- * just future ones.
+ * <b>{@code detectLeaks} also gates emission at report time:</b> {@link #drain()} re-reads
+ * {@link MeterConfig#detectLeaks} and stays silent when it is {@code false}, still cleaning up the registry. So
+ * turning the toggle off at runtime suppresses pending leak reports for meters that were already registered, not just
+ * future ones.
  * <p>
- * <b>Tail draining on shutdown:</b> the opportunistic drain only reports meters the garbage collector has already
- * reclaimed. Meters that are forgotten but never collected during the application's life would otherwise go
- * unreported. When {@link MeterConfig#reportLeaksOnShutdown} is enabled, a JVM shutdown hook is installed lazily (on
- * the first tracked meter) that runs {@link #reportRemainingLeaks()}, reporting every meter still registered at
- * shutdown.
+ * <b>No JVM shutdown hook:</b> detection is purely garbage-collection driven. A meter that is forgotten but never
+ * collected before the JVM exits is not reported — by design, to avoid installing a JVM shutdown hook, which in a
+ * servlet container would pin the web application class loader across redeploys. Such a meter does not leak memory
+ * (it is only weakly referenced); it simply goes unreported.
  *
  * @author Daniel Felix Ferber
  * @see Meter
  * @see MeterConfig#detectLeaks
- * @see MeterConfig#reportLeaksOnShutdown
  */
 final class MeterLeakDetector {
 
@@ -84,12 +81,6 @@ final class MeterLeakDetector {
 
     /** Head of the intrusive doubly-linked list of currently registered references; {@code null} when empty. */
     private static MeterReference head;
-
-    /** Ensures the shutdown hook is installed at most once. */
-    private static final AtomicBoolean shutdownHookInstalled = new AtomicBoolean(false);
-
-    /** The installed shutdown hook thread, retained so tests can remove it. */
-    private static volatile Thread shutdownHook;
 
     /**
      * A {@link WeakReference} to a started {@link Meter} that doubles as both the node of the thread-local stack and,
@@ -152,9 +143,6 @@ final class MeterLeakDetector {
             return ref;
         }
         drain();
-        if (MeterConfig.reportLeaksOnShutdown) {
-            installShutdownHookOnce();
-        }
         final MeterReference ref = new MeterReference(meter, QUEUE);
         ref.previousInstance = previous;
         synchronized (LOCK) {
@@ -213,63 +201,6 @@ final class MeterLeakDetector {
     }
 
     /**
-     * Reports every meter still registered (started and never stopped) and empties the registry. This is the tail
-     * drain run on JVM shutdown: unlike {@link #drain()}, which only reports meters the garbage collector has already
-     * reclaimed, this reports the complete set of outstanding leaks regardless of collection.
-     * <p>
-     * The list is detached and the references marked unregistered under the lock — so a concurrent {@link #drain()}
-     * will not double-report — while the actual logging happens outside the lock, since {@link MeterReference#reportLeak()}
-     * may be slow or reentrant.
-     */
-    static void reportRemainingLeaks() {
-        /* Like drain(), detectLeaks gates emission: the sweep always empties the registry, but reports only when
-           leak detection is enabled at the moment it runs. */
-        final boolean report = MeterConfig.detectLeaks;
-        final MeterReference chain;
-        synchronized (LOCK) {
-            chain = head;
-            head = null;
-            for (MeterReference ref = chain; ref != null; ref = ref.next) {
-                ref.prev = null;
-                ref.registered = false;
-            }
-        }
-        for (MeterReference ref = chain; ref != null; ) {
-            final MeterReference next = ref.next;
-            ref.next = null;
-            if (report) {
-                ref.reportLeak();
-            }
-            ref = next;
-        }
-    }
-
-    /**
-     * Installs the JVM shutdown hook that runs {@link #reportRemainingLeaks()}, at most once per JVM.
-     */
-    private static void installShutdownHookOnce() {
-        if (shutdownHookInstalled.compareAndSet(false, true)) {
-            final Thread hook = new Thread(MeterLeakDetector::runShutdownReport, "slf4j-toys-MeterLeakDetector-shutdown");
-            shutdownHook = hook;
-            Runtime.getRuntime().addShutdownHook(hook);
-        }
-    }
-
-    /**
-     * Body of the shutdown hook: reports remaining leaks if still enabled, swallowing any error so shutdown is never
-     * disrupted.
-     */
-    private static void runShutdownReport() {
-        try {
-            if (MeterConfig.reportLeaksOnShutdown) {
-                reportRemainingLeaks();
-            }
-        } catch (final Exception ignored) {
-            // A shutdown hook must never throw; a failed leak report is not worth disrupting shutdown.
-        }
-    }
-
-    /**
      * Unlinks a reference from the intrusive registry. Caller must hold {@link #LOCK}. Idempotent. Does not touch the
      * {@code previousInstance} stack link.
      */
@@ -301,29 +232,5 @@ final class MeterLeakDetector {
             }
         }
         return count;
-    }
-
-    /**
-     * The installed shutdown hook thread, or {@code null} if none was installed. For tests only.
-     */
-    static Thread shutdownHookForTests() {
-        return shutdownHook;
-    }
-
-    /**
-     * Removes and forgets the installed shutdown hook, allowing it to be reinstalled. For tests only, to avoid
-     * leaking a real JVM shutdown hook across the test suite.
-     */
-    static void resetShutdownHookForTests() {
-        final Thread hook = shutdownHook;
-        if (hook != null) {
-            try {
-                Runtime.getRuntime().removeShutdownHook(hook);
-            } catch (final IllegalStateException ignored) {
-                // JVM already shutting down; nothing to remove.
-            }
-            shutdownHook = null;
-        }
-        shutdownHookInstalled.set(false);
     }
 }

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
@@ -54,6 +54,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@link MeterConfig#detectLeaks} toggle are applied in {@link #track(Meter, MeterReference)}; when leak detection is
  * off, the reference is still created to serve as the stack node, but is neither queued nor registered.
  * <p>
+ * <b>{@code detectLeaks} also gates emission at report time:</b> {@link #drain()} and {@link #reportRemainingLeaks()}
+ * re-read {@link MeterConfig#detectLeaks} and stay silent when it is {@code false}, still cleaning up the registry.
+ * So turning the toggle off at runtime suppresses pending leak reports for meters that were already registered, not
+ * just future ones.
+ * <p>
  * <b>Tail draining on shutdown:</b> the opportunistic drain only reports meters the garbage collector has already
  * reclaimed. Meters that are forgotten but never collected during the application's life would otherwise go
  * unreported. When {@link MeterConfig#reportLeaksOnShutdown} is enabled, a JVM shutdown hook is installed lazily (on
@@ -190,6 +195,9 @@ final class MeterLeakDetector {
      * Safe to call from any thread; invoked opportunistically by {@link #track(Meter, MeterReference)}.
      */
     static void drain() {
+        /* Read the toggle once: it gates emission at report time, so turning detectLeaks off at runtime suppresses
+           pending leaks. The queue is still drained and unlinked to keep the registry from growing unbounded. */
+        final boolean report = MeterConfig.detectLeaks;
         Reference<? extends Meter> r;
         while ((r = QUEUE.poll()) != null) {
             final MeterReference ref = (MeterReference) r;
@@ -198,7 +206,7 @@ final class MeterLeakDetector {
                 wasRegistered = ref.registered;
                 unlink(ref);
             }
-            if (wasRegistered) {
+            if (wasRegistered && report) {
                 ref.reportLeak();
             }
         }
@@ -214,6 +222,9 @@ final class MeterLeakDetector {
      * may be slow or reentrant.
      */
     static void reportRemainingLeaks() {
+        /* Like drain(), detectLeaks gates emission: the sweep always empties the registry, but reports only when
+           leak detection is enabled at the moment it runs. */
+        final boolean report = MeterConfig.detectLeaks;
         final MeterReference chain;
         synchronized (LOCK) {
             chain = head;
@@ -226,7 +237,9 @@ final class MeterLeakDetector {
         for (MeterReference ref = chain; ref != null; ) {
             final MeterReference next = ref.next;
             ref.next = null;
-            ref.reportLeak();
+            if (report) {
+                ref.reportLeak();
+            }
             ref = next;
         }
     }

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Forward-compatible detector for {@link Meter} instances that were started but never explicitly stopped
@@ -44,10 +45,17 @@ import java.lang.ref.ReferenceQueue;
  * <em>while still registered</em> is, by definition, a meter that was started and never stopped — exactly the
  * predicate the former {@code finalize()} path checked. The {@code UNKNOWN_LOGGER_NAME} exclusion and the
  * {@link MeterConfig#detectLeaks} toggle are enforced by the caller, keeping this class a pure mechanism.
+ * <p>
+ * <b>Tail draining on shutdown:</b> the opportunistic drain only reports meters the garbage collector has already
+ * reclaimed. Meters that are forgotten but never collected during the application's life would otherwise go
+ * unreported. When {@link MeterConfig#reportLeaksOnShutdown} is enabled, a JVM shutdown hook is installed lazily (on
+ * the first registration) that runs {@link #reportRemainingLeaks()}, reporting every meter still registered at
+ * shutdown.
  *
  * @author Daniel Felix Ferber
  * @see Meter
  * @see MeterConfig#detectLeaks
+ * @see MeterConfig#reportLeaksOnShutdown
  */
 final class MeterLeakDetector {
 
@@ -63,6 +71,12 @@ final class MeterLeakDetector {
 
     /** Head of the intrusive doubly-linked list of currently registered references; {@code null} when empty. */
     private static MeterReference head;
+
+    /** Ensures the shutdown hook is installed at most once. */
+    private static final AtomicBoolean shutdownHookInstalled = new AtomicBoolean(false);
+
+    /** The installed shutdown hook thread, retained so tests can remove it. */
+    private static volatile Thread shutdownHook;
 
     /**
      * A {@link PhantomReference} to a started {@link Meter} that doubles as the node of the intrusive linked list.
@@ -104,6 +118,9 @@ final class MeterLeakDetector {
      */
     static MeterReference register(final Meter meter) {
         drain();
+        if (MeterConfig.reportLeaksOnShutdown) {
+            installShutdownHookOnce();
+        }
         final MeterReference ref = new MeterReference(meter, QUEUE);
         synchronized (LOCK) {
             ref.next = head;
@@ -153,6 +170,59 @@ final class MeterLeakDetector {
     }
 
     /**
+     * Reports every meter still registered (started and never stopped) and empties the registry. This is the tail
+     * drain run on JVM shutdown: unlike {@link #drain()}, which only reports meters the garbage collector has already
+     * reclaimed, this reports the complete set of outstanding leaks regardless of collection.
+     * <p>
+     * The list is detached and the references marked unregistered under the lock — so a concurrent {@link #drain()}
+     * will not double-report — while the actual logging happens outside the lock, since {@link MeterReference#reportLeak()}
+     * may be slow or reentrant.
+     */
+    static void reportRemainingLeaks() {
+        final MeterReference chain;
+        synchronized (LOCK) {
+            chain = head;
+            head = null;
+            for (MeterReference ref = chain; ref != null; ref = ref.next) {
+                ref.prev = null;
+                ref.registered = false;
+            }
+        }
+        for (MeterReference ref = chain; ref != null; ) {
+            final MeterReference next = ref.next;
+            ref.next = null;
+            ref.reportLeak();
+            ref.clear();
+            ref = next;
+        }
+    }
+
+    /**
+     * Installs the JVM shutdown hook that runs {@link #reportRemainingLeaks()}, at most once per JVM.
+     */
+    private static void installShutdownHookOnce() {
+        if (shutdownHookInstalled.compareAndSet(false, true)) {
+            final Thread hook = new Thread(MeterLeakDetector::runShutdownReport, "slf4j-toys-MeterLeakDetector-shutdown");
+            shutdownHook = hook;
+            Runtime.getRuntime().addShutdownHook(hook);
+        }
+    }
+
+    /**
+     * Body of the shutdown hook: reports remaining leaks if still enabled, swallowing any error so shutdown is never
+     * disrupted.
+     */
+    private static void runShutdownReport() {
+        try {
+            if (MeterConfig.reportLeaksOnShutdown) {
+                reportRemainingLeaks();
+            }
+        } catch (final Exception ignored) {
+            // A shutdown hook must never throw; a failed leak report is not worth disrupting shutdown.
+        }
+    }
+
+    /**
      * Unlinks a reference from the intrusive list. Caller must hold {@link #LOCK}. Idempotent.
      */
     private static void unlink(final MeterReference ref) {
@@ -183,5 +253,29 @@ final class MeterLeakDetector {
             }
         }
         return count;
+    }
+
+    /**
+     * The installed shutdown hook thread, or {@code null} if none was installed. For tests only.
+     */
+    static Thread shutdownHookForTests() {
+        return shutdownHook;
+    }
+
+    /**
+     * Removes and forgets the installed shutdown hook, allowing it to be reinstalled. For tests only, to avoid
+     * leaking a real JVM shutdown hook across the test suite.
+     */
+    static void resetShutdownHookForTests() {
+        final Thread hook = shutdownHook;
+        if (hook != null) {
+            try {
+                Runtime.getRuntime().removeShutdownHook(hook);
+            } catch (final IllegalStateException ignored) {
+                // JVM already shutting down; nothing to remove.
+            }
+            shutdownHook = null;
+        }
+        shutdownHookInstalled.set(false);
     }
 }

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
@@ -328,20 +328,6 @@ public class MeterValidator {
     }
 
 
-    /* ========== Validate Finalize Method ========== */
-
-    /**
-     * Validates the state of a Meter instance during finalization.
-     * Logs an error if a Meter was started but never explicitly stopped.
-     *
-     * @param meter The Meter instance being finalized.
-     */
-    void validateFinalize(final Meter meter) {
-        if (meter.getStartTime() != 0 && meter.getStopTime() == 0 && !meter.getCategory().equals(Meter.UNKNOWN_LOGGER_NAME)) {
-            meter.getMessageLogger().error(Markers.INVALID_ARGUMENT, "{}; id={}", "Meter never stopped, must remember to call ok/reject/fail/success() on each started one", meter.getFullID());
-        }
-    }
-
     /* ========== Utility Methods ========== */
 
     void logInvalidStateAlreadyStopped(final Meter meter) {

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
@@ -62,6 +62,7 @@ class MeterConfigTest {
         assertFalse(MeterConfig.printLoad, "Default value for printLoad should be false");
         assertFalse(MeterConfig.printMemory, "Default value for printMemory should be false");
         assertTrue(MeterConfig.detectLeaks, "Default value for detectLeaks should be true");
+        assertFalse(MeterConfig.reportLeaksOnShutdown, "Default value for reportLeaksOnShutdown should be false");
         assertEquals("", MeterConfig.dataPrefix, "Default value for dataPrefix should be an empty string");
         assertEquals("", MeterConfig.dataSuffix, "Default value for dataSuffix should be an empty string");
         assertEquals("", MeterConfig.messagePrefix, "Default value for messagePrefix should be an empty string");
@@ -83,6 +84,7 @@ class MeterConfigTest {
         assertFalse(MeterConfig.printLoad, "Default value for printLoad should be false");
         assertFalse(MeterConfig.printMemory, "Default value for printMemory should be false");
         assertTrue(MeterConfig.detectLeaks, "Default value for detectLeaks should be true");
+        assertFalse(MeterConfig.reportLeaksOnShutdown, "Default value for reportLeaksOnShutdown should be false");
         assertEquals("", MeterConfig.dataPrefix, "Default value for dataPrefix should be an empty string");
         assertEquals("", MeterConfig.dataSuffix, "Default value for dataSuffix should be an empty string");
         assertEquals("", MeterConfig.messagePrefix, "Default value for messagePrefix should be an empty string");
@@ -115,6 +117,32 @@ class MeterConfigTest {
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid detectLeaks format");
         assertEquals(1, ConfigParser.initializationErrors.size());
         assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_DETECT_LEAKS));
+    }
+
+    /**
+     * Tests that reportLeaksOnShutdown property is correctly parsed from system property.
+     */
+    @Test
+    @DisplayName("should parse reportLeaksOnShutdown property correctly")
+    void testReportLeaksOnShutdownProperty() {
+        System.setProperty(MeterConfig.PROP_REPORT_LEAKS_ON_SHUTDOWN, "true");
+        MeterConfig.init();
+        assertTrue(MeterConfig.reportLeaksOnShutdown, "reportLeaksOnShutdown should reflect the system property value");
+        assertTrue(ConfigParser.isInitializationOK(), "No errors should be reported for valid reportLeaksOnShutdown");
+    }
+
+    /**
+     * Tests that invalid reportLeaksOnShutdown property falls back to default and reports error.
+     */
+    @Test
+    @DisplayName("should handle invalid reportLeaksOnShutdown format")
+    void testReportLeaksOnShutdownInvalidFormat() {
+        System.setProperty(MeterConfig.PROP_REPORT_LEAKS_ON_SHUTDOWN, "invalid");
+        MeterConfig.init();
+        assertFalse(MeterConfig.reportLeaksOnShutdown, "reportLeaksOnShutdown should fall back to default for invalid format");
+        assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid reportLeaksOnShutdown format");
+        assertEquals(1, ConfigParser.initializationErrors.size());
+        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_REPORT_LEAKS_ON_SHUTDOWN));
     }
 
     /**

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
@@ -62,7 +62,6 @@ class MeterConfigTest {
         assertFalse(MeterConfig.printLoad, "Default value for printLoad should be false");
         assertFalse(MeterConfig.printMemory, "Default value for printMemory should be false");
         assertTrue(MeterConfig.detectLeaks, "Default value for detectLeaks should be true");
-        assertFalse(MeterConfig.reportLeaksOnShutdown, "Default value for reportLeaksOnShutdown should be false");
         assertEquals("", MeterConfig.dataPrefix, "Default value for dataPrefix should be an empty string");
         assertEquals("", MeterConfig.dataSuffix, "Default value for dataSuffix should be an empty string");
         assertEquals("", MeterConfig.messagePrefix, "Default value for messagePrefix should be an empty string");
@@ -84,7 +83,6 @@ class MeterConfigTest {
         assertFalse(MeterConfig.printLoad, "Default value for printLoad should be false");
         assertFalse(MeterConfig.printMemory, "Default value for printMemory should be false");
         assertTrue(MeterConfig.detectLeaks, "Default value for detectLeaks should be true");
-        assertFalse(MeterConfig.reportLeaksOnShutdown, "Default value for reportLeaksOnShutdown should be false");
         assertEquals("", MeterConfig.dataPrefix, "Default value for dataPrefix should be an empty string");
         assertEquals("", MeterConfig.dataSuffix, "Default value for dataSuffix should be an empty string");
         assertEquals("", MeterConfig.messagePrefix, "Default value for messagePrefix should be an empty string");
@@ -117,32 +115,6 @@ class MeterConfigTest {
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid detectLeaks format");
         assertEquals(1, ConfigParser.initializationErrors.size());
         assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_DETECT_LEAKS));
-    }
-
-    /**
-     * Tests that reportLeaksOnShutdown property is correctly parsed from system property.
-     */
-    @Test
-    @DisplayName("should parse reportLeaksOnShutdown property correctly")
-    void testReportLeaksOnShutdownProperty() {
-        System.setProperty(MeterConfig.PROP_REPORT_LEAKS_ON_SHUTDOWN, "true");
-        MeterConfig.init();
-        assertTrue(MeterConfig.reportLeaksOnShutdown, "reportLeaksOnShutdown should reflect the system property value");
-        assertTrue(ConfigParser.isInitializationOK(), "No errors should be reported for valid reportLeaksOnShutdown");
-    }
-
-    /**
-     * Tests that invalid reportLeaksOnShutdown property falls back to default and reports error.
-     */
-    @Test
-    @DisplayName("should handle invalid reportLeaksOnShutdown format")
-    void testReportLeaksOnShutdownInvalidFormat() {
-        System.setProperty(MeterConfig.PROP_REPORT_LEAKS_ON_SHUTDOWN, "invalid");
-        MeterConfig.init();
-        assertFalse(MeterConfig.reportLeaksOnShutdown, "reportLeaksOnShutdown should fall back to default for invalid format");
-        assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid reportLeaksOnShutdown format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_REPORT_LEAKS_ON_SHUTDOWN));
     }
 
     /**

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
@@ -61,6 +61,7 @@ class MeterConfigTest {
         assertFalse(MeterConfig.printPosition, "Default value for printPosition should be false");
         assertFalse(MeterConfig.printLoad, "Default value for printLoad should be false");
         assertFalse(MeterConfig.printMemory, "Default value for printMemory should be false");
+        assertTrue(MeterConfig.detectLeaks, "Default value for detectLeaks should be true");
         assertEquals("", MeterConfig.dataPrefix, "Default value for dataPrefix should be an empty string");
         assertEquals("", MeterConfig.dataSuffix, "Default value for dataSuffix should be an empty string");
         assertEquals("", MeterConfig.messagePrefix, "Default value for messagePrefix should be an empty string");
@@ -81,6 +82,7 @@ class MeterConfigTest {
         assertFalse(MeterConfig.printPosition, "Default value for printPosition should be false");
         assertFalse(MeterConfig.printLoad, "Default value for printLoad should be false");
         assertFalse(MeterConfig.printMemory, "Default value for printMemory should be false");
+        assertTrue(MeterConfig.detectLeaks, "Default value for detectLeaks should be true");
         assertEquals("", MeterConfig.dataPrefix, "Default value for dataPrefix should be an empty string");
         assertEquals("", MeterConfig.dataSuffix, "Default value for dataSuffix should be an empty string");
         assertEquals("", MeterConfig.messagePrefix, "Default value for messagePrefix should be an empty string");
@@ -88,6 +90,32 @@ class MeterConfigTest {
         assertTrue(ConfigParser.isInitializationOK(), "No errors should be reported after reset");
     }
 
+
+    /**
+     * Tests that detectLeaks property is correctly parsed from system property.
+     */
+    @Test
+    @DisplayName("should parse detectLeaks property correctly")
+    void testDetectLeaksProperty() {
+        System.setProperty(MeterConfig.PROP_DETECT_LEAKS, "false");
+        MeterConfig.init();
+        assertFalse(MeterConfig.detectLeaks, "detectLeaks should reflect the system property value");
+        assertTrue(ConfigParser.isInitializationOK(), "No errors should be reported for valid detectLeaks");
+    }
+
+    /**
+     * Tests that invalid detectLeaks property falls back to default and reports error.
+     */
+    @Test
+    @DisplayName("should handle invalid detectLeaks format")
+    void testDetectLeaksInvalidFormat() {
+        System.setProperty(MeterConfig.PROP_DETECT_LEAKS, "invalid");
+        MeterConfig.init();
+        assertTrue(MeterConfig.detectLeaks, "detectLeaks should fall back to default for invalid format");
+        assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid detectLeaks format");
+        assertEquals(1, ConfigParser.initializationErrors.size());
+        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_DETECT_LEAKS));
+    }
 
     /**
      * Tests that progressPeriodMilliseconds property is correctly parsed from system property.

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
@@ -182,6 +182,16 @@ class MeterLeakDetectorTest {
     }
 
     @Test
+    @DisplayName("reportRemainingLeaks empties the registry but stays silent when detectLeaks is turned off at runtime")
+    void reportRemainingLeaksSuppressedWhenDetectLeaksDisabled() {
+        MeterLeakDetector.track(meter, null); // registered while detectLeaks is on (default)
+        MeterConfig.detectLeaks = false;      // turned off at runtime, after registration
+        MeterLeakDetector.reportRemainingLeaks();
+        assertEquals(0, MeterLeakDetector.trackedCount(), "the sweep must still empty the registry");
+        assertNoEvents(logger);
+    }
+
+    @Test
     @DisplayName("reportRemainingLeaks on an empty registry should be a no-op")
     void reportRemainingLeaksEmptyIsNoOp() {
         MeterLeakDetector.reportRemainingLeaks();

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.impl.MockLoggerEvent;
+import org.usefultoys.slf4j.meter.MeterLeakDetector.MeterReference;
+import org.usefultoys.slf4jtestmock.Slf4jMock;
+import org.usefultoys.slf4jtestmock.WithMockLogger;
+import org.usefultoys.test.ResetMeterConfig;
+import org.usefultoys.test.ValidateCharset;
+import org.usefultoys.test.ValidateCleanMeter;
+
+import java.lang.ref.ReferenceQueue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.lenient;
+import static org.usefultoys.slf4jtestmock.AssertLogger.assertEvent;
+import static org.usefultoys.slf4jtestmock.AssertLogger.assertNoEvents;
+
+/**
+ * Unit tests for {@link MeterLeakDetector}.
+ * <p>
+ * These tests exercise the detector's logic deterministically, without relying on garbage collection:
+ * <ul>
+ *   <li><b>List mechanics:</b> {@code register}/{@code deregister} keep the intrusive list consistent and idempotent.</li>
+ *   <li><b>Null safety:</b> {@code deregister(null)} and draining an empty queue are no-ops.</li>
+ *   <li><b>Report contract:</b> {@link MeterReference#reportLeak()} emits the exact message and marker formerly
+ *       produced by {@code MeterValidator.validateFinalize}, from the snapshot captured at registration.</li>
+ * </ul>
+ * The end-to-end garbage-collection path (collection → enqueue → {@code drain} → report) is covered by
+ * {@code MeterThreadLocalWeakReferenceGcTest}.
+ */
+@ValidateCharset
+@ResetMeterConfig
+@WithMockLogger
+@ValidateCleanMeter
+class MeterLeakDetectorTest {
+
+    @Mock
+    protected Meter meter;
+
+    @Slf4jMock
+    protected Logger logger;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        lenient().when(meter.getMessageLogger()).thenReturn(logger);
+        lenient().when(meter.getFullID()).thenReturn("test-id");
+    }
+
+    @Test
+    @DisplayName("register should return a handle and track exactly one reference")
+    void registerTracksOneReference() {
+        assertEquals(0, MeterLeakDetector.trackedCount(), "no references should be tracked initially");
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        try {
+            assertNotNull(ref, "register should return a non-null handle");
+            assertEquals(1, MeterLeakDetector.trackedCount(), "exactly one reference should be tracked after register");
+            assertNoEvents(logger);
+        } finally {
+            MeterLeakDetector.deregister(ref);
+        }
+    }
+
+    @Test
+    @DisplayName("deregister should stop tracking the reference")
+    void deregisterStopsTracking() {
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        MeterLeakDetector.deregister(ref);
+        assertEquals(0, MeterLeakDetector.trackedCount(), "no references should be tracked after deregister");
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("deregister should be idempotent")
+    void deregisterIsIdempotent() {
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        MeterLeakDetector.deregister(ref);
+        MeterLeakDetector.deregister(ref);
+        assertEquals(0, MeterLeakDetector.trackedCount(), "double deregister should not corrupt the list");
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("deregister should tolerate a null handle")
+    void deregisterToleratesNull() {
+        MeterLeakDetector.deregister(null);
+        assertEquals(0, MeterLeakDetector.trackedCount(), "deregister(null) must be a no-op");
+    }
+
+    @Test
+    @DisplayName("multiple registrations should be tracked and individually deregistered")
+    void multipleRegistrationsAreTrackedIndependently() {
+        final MeterReference ref1 = MeterLeakDetector.register(meter);
+        final MeterReference ref2 = MeterLeakDetector.register(meter);
+        final MeterReference ref3 = MeterLeakDetector.register(meter);
+        try {
+            assertEquals(3, MeterLeakDetector.trackedCount(), "three references should be tracked");
+            MeterLeakDetector.deregister(ref2);
+            assertEquals(2, MeterLeakDetector.trackedCount(), "deregistering a middle node keeps the list consistent");
+            MeterLeakDetector.deregister(ref1);
+            assertEquals(1, MeterLeakDetector.trackedCount(), "deregistering the tail node keeps the list consistent");
+            MeterLeakDetector.deregister(ref3);
+            assertEquals(0, MeterLeakDetector.trackedCount(), "deregistering the head node empties the list");
+        } finally {
+            MeterLeakDetector.deregister(ref1);
+            MeterLeakDetector.deregister(ref2);
+            MeterLeakDetector.deregister(ref3);
+        }
+    }
+
+    @Test
+    @DisplayName("drain on an empty queue should be a no-op")
+    void drainEmptyQueueIsNoOp() {
+        MeterLeakDetector.drain();
+        assertEquals(0, MeterLeakDetector.trackedCount(), "draining an empty queue should not change tracking");
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("reportLeak should emit the forgotten-meter error from the captured snapshot")
+    void reportLeakEmitsForgottenMeterError() {
+        final MeterReference ref = new MeterReference(meter, new ReferenceQueue<Meter>());
+        ref.reportLeak();
+        assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
+                "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
+    }
+}

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
+import org.slf4j.impl.MockLogger;
 import org.slf4j.impl.MockLoggerEvent;
 import org.usefultoys.slf4j.meter.MeterLeakDetector.MeterReference;
 import org.usefultoys.slf4jtestmock.Slf4jMock;
@@ -33,6 +34,8 @@ import java.lang.ref.ReferenceQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.lenient;
 import static org.usefultoys.slf4jtestmock.AssertLogger.assertEvent;
 import static org.usefultoys.slf4jtestmock.AssertLogger.assertNoEvents;
@@ -145,5 +148,81 @@ class MeterLeakDetectorTest {
         ref.reportLeak();
         assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
                 "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
+    }
+
+    @Test
+    @DisplayName("reportRemainingLeaks should report every still-registered meter and empty the registry")
+    void reportRemainingLeaksReportsAllRegistered() {
+        MeterLeakDetector.register(meter);
+        MeterLeakDetector.register(meter);
+        assertEquals(2, MeterLeakDetector.trackedCount(), "both meters should be tracked before the sweep");
+
+        MeterLeakDetector.reportRemainingLeaks();
+
+        assertEquals(0, MeterLeakDetector.trackedCount(), "the registry must be empty after the sweep");
+        assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
+                "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
+        assertEvent(logger, 1, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
+                "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
+    }
+
+    @Test
+    @DisplayName("reportRemainingLeaks should be idempotent and not double-report")
+    void reportRemainingLeaksIsIdempotent() {
+        MeterLeakDetector.register(meter);
+        MeterLeakDetector.reportRemainingLeaks();
+        MeterLeakDetector.reportRemainingLeaks();
+        assertEquals(0, MeterLeakDetector.trackedCount(), "registry must stay empty");
+        assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
+                "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
+        assertEquals(1, ((MockLogger) logger).getLoggerEvents().size(),
+                "a forgotten meter must be reported exactly once across repeated sweeps");
+    }
+
+    @Test
+    @DisplayName("reportRemainingLeaks on an empty registry should be a no-op")
+    void reportRemainingLeaksEmptyIsNoOp() {
+        MeterLeakDetector.reportRemainingLeaks();
+        assertEquals(0, MeterLeakDetector.trackedCount());
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("a deregistered meter is not reported by the shutdown sweep")
+    void deregisteredMeterIsNotReportedOnShutdownSweep() {
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        MeterLeakDetector.deregister(ref);
+        MeterLeakDetector.reportRemainingLeaks();
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("enabling reportLeaksOnShutdown installs a shutdown hook at most once")
+    void enablingReportLeaksOnShutdownInstallsHookOnce() {
+        MeterConfig.reportLeaksOnShutdown = true;
+        final MeterReference ref1 = MeterLeakDetector.register(meter);
+        try {
+            final Thread hook = MeterLeakDetector.shutdownHookForTests();
+            assertNotNull(hook, "a shutdown hook must be installed when reportLeaksOnShutdown is enabled");
+            final MeterReference ref2 = MeterLeakDetector.register(meter);
+            assertSame(hook, MeterLeakDetector.shutdownHookForTests(), "the hook must be installed at most once");
+            MeterLeakDetector.deregister(ref2);
+        } finally {
+            MeterLeakDetector.deregister(ref1);
+            MeterLeakDetector.resetShutdownHookForTests();
+        }
+    }
+
+    @Test
+    @DisplayName("no shutdown hook is installed when reportLeaksOnShutdown is disabled")
+    void disabledReportLeaksOnShutdownInstallsNoHook() {
+        // reportLeaksOnShutdown defaults to false (restored by @ResetMeterConfig)
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        try {
+            assertNull(MeterLeakDetector.shutdownHookForTests(),
+                    "no shutdown hook should be installed when the option is disabled");
+        } finally {
+            MeterLeakDetector.deregister(ref);
+        }
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
@@ -45,8 +45,10 @@ import static org.usefultoys.slf4jtestmock.AssertLogger.assertNoEvents;
  * <p>
  * These tests exercise the detector's logic deterministically, without relying on garbage collection:
  * <ul>
- *   <li><b>List mechanics:</b> {@code register}/{@code deregister} keep the intrusive list consistent and idempotent.</li>
- *   <li><b>Null safety:</b> {@code deregister(null)} and draining an empty queue are no-ops.</li>
+ *   <li><b>List mechanics:</b> {@code track}/{@code untrack} keep the intrusive registry consistent and idempotent.</li>
+ *   <li><b>Null safety:</b> {@code untrack(null)} and draining an empty queue are no-ops.</li>
+ *   <li><b>Stack-node unification:</b> {@code track} chains {@code previousInstance} and, when leak detection is off
+ *       or the category is the dummy {@code "???"}, still returns a usable stack node without registering it.</li>
  *   <li><b>Report contract:</b> {@link MeterReference#reportLeak()} emits the exact message and marker formerly
  *       produced by {@code MeterValidator.validateFinalize}, from the snapshot captured at registration.</li>
  * </ul>
@@ -76,21 +78,21 @@ class MeterLeakDetectorTest {
     @DisplayName("register should return a handle and track exactly one reference")
     void registerTracksOneReference() {
         assertEquals(0, MeterLeakDetector.trackedCount(), "no references should be tracked initially");
-        final MeterReference ref = MeterLeakDetector.register(meter);
+        final MeterReference ref = MeterLeakDetector.track(meter, null);
         try {
             assertNotNull(ref, "register should return a non-null handle");
             assertEquals(1, MeterLeakDetector.trackedCount(), "exactly one reference should be tracked after register");
             assertNoEvents(logger);
         } finally {
-            MeterLeakDetector.deregister(ref);
+            MeterLeakDetector.untrack(ref);
         }
     }
 
     @Test
     @DisplayName("deregister should stop tracking the reference")
     void deregisterStopsTracking() {
-        final MeterReference ref = MeterLeakDetector.register(meter);
-        MeterLeakDetector.deregister(ref);
+        final MeterReference ref = MeterLeakDetector.track(meter, null);
+        MeterLeakDetector.untrack(ref);
         assertEquals(0, MeterLeakDetector.trackedCount(), "no references should be tracked after deregister");
         assertNoEvents(logger);
     }
@@ -98,9 +100,9 @@ class MeterLeakDetectorTest {
     @Test
     @DisplayName("deregister should be idempotent")
     void deregisterIsIdempotent() {
-        final MeterReference ref = MeterLeakDetector.register(meter);
-        MeterLeakDetector.deregister(ref);
-        MeterLeakDetector.deregister(ref);
+        final MeterReference ref = MeterLeakDetector.track(meter, null);
+        MeterLeakDetector.untrack(ref);
+        MeterLeakDetector.untrack(ref);
         assertEquals(0, MeterLeakDetector.trackedCount(), "double deregister should not corrupt the list");
         assertNoEvents(logger);
     }
@@ -108,28 +110,28 @@ class MeterLeakDetectorTest {
     @Test
     @DisplayName("deregister should tolerate a null handle")
     void deregisterToleratesNull() {
-        MeterLeakDetector.deregister(null);
+        MeterLeakDetector.untrack(null);
         assertEquals(0, MeterLeakDetector.trackedCount(), "deregister(null) must be a no-op");
     }
 
     @Test
     @DisplayName("multiple registrations should be tracked and individually deregistered")
     void multipleRegistrationsAreTrackedIndependently() {
-        final MeterReference ref1 = MeterLeakDetector.register(meter);
-        final MeterReference ref2 = MeterLeakDetector.register(meter);
-        final MeterReference ref3 = MeterLeakDetector.register(meter);
+        final MeterReference ref1 = MeterLeakDetector.track(meter, null);
+        final MeterReference ref2 = MeterLeakDetector.track(meter, null);
+        final MeterReference ref3 = MeterLeakDetector.track(meter, null);
         try {
             assertEquals(3, MeterLeakDetector.trackedCount(), "three references should be tracked");
-            MeterLeakDetector.deregister(ref2);
+            MeterLeakDetector.untrack(ref2);
             assertEquals(2, MeterLeakDetector.trackedCount(), "deregistering a middle node keeps the list consistent");
-            MeterLeakDetector.deregister(ref1);
+            MeterLeakDetector.untrack(ref1);
             assertEquals(1, MeterLeakDetector.trackedCount(), "deregistering the tail node keeps the list consistent");
-            MeterLeakDetector.deregister(ref3);
+            MeterLeakDetector.untrack(ref3);
             assertEquals(0, MeterLeakDetector.trackedCount(), "deregistering the head node empties the list");
         } finally {
-            MeterLeakDetector.deregister(ref1);
-            MeterLeakDetector.deregister(ref2);
-            MeterLeakDetector.deregister(ref3);
+            MeterLeakDetector.untrack(ref1);
+            MeterLeakDetector.untrack(ref2);
+            MeterLeakDetector.untrack(ref3);
         }
     }
 
@@ -153,8 +155,8 @@ class MeterLeakDetectorTest {
     @Test
     @DisplayName("reportRemainingLeaks should report every still-registered meter and empty the registry")
     void reportRemainingLeaksReportsAllRegistered() {
-        MeterLeakDetector.register(meter);
-        MeterLeakDetector.register(meter);
+        MeterLeakDetector.track(meter, null);
+        MeterLeakDetector.track(meter, null);
         assertEquals(2, MeterLeakDetector.trackedCount(), "both meters should be tracked before the sweep");
 
         MeterLeakDetector.reportRemainingLeaks();
@@ -169,7 +171,7 @@ class MeterLeakDetectorTest {
     @Test
     @DisplayName("reportRemainingLeaks should be idempotent and not double-report")
     void reportRemainingLeaksIsIdempotent() {
-        MeterLeakDetector.register(meter);
+        MeterLeakDetector.track(meter, null);
         MeterLeakDetector.reportRemainingLeaks();
         MeterLeakDetector.reportRemainingLeaks();
         assertEquals(0, MeterLeakDetector.trackedCount(), "registry must stay empty");
@@ -190,8 +192,8 @@ class MeterLeakDetectorTest {
     @Test
     @DisplayName("a deregistered meter is not reported by the shutdown sweep")
     void deregisteredMeterIsNotReportedOnShutdownSweep() {
-        final MeterReference ref = MeterLeakDetector.register(meter);
-        MeterLeakDetector.deregister(ref);
+        final MeterReference ref = MeterLeakDetector.track(meter, null);
+        MeterLeakDetector.untrack(ref);
         MeterLeakDetector.reportRemainingLeaks();
         assertNoEvents(logger);
     }
@@ -200,15 +202,15 @@ class MeterLeakDetectorTest {
     @DisplayName("enabling reportLeaksOnShutdown installs a shutdown hook at most once")
     void enablingReportLeaksOnShutdownInstallsHookOnce() {
         MeterConfig.reportLeaksOnShutdown = true;
-        final MeterReference ref1 = MeterLeakDetector.register(meter);
+        final MeterReference ref1 = MeterLeakDetector.track(meter, null);
         try {
             final Thread hook = MeterLeakDetector.shutdownHookForTests();
             assertNotNull(hook, "a shutdown hook must be installed when reportLeaksOnShutdown is enabled");
-            final MeterReference ref2 = MeterLeakDetector.register(meter);
+            final MeterReference ref2 = MeterLeakDetector.track(meter, null);
             assertSame(hook, MeterLeakDetector.shutdownHookForTests(), "the hook must be installed at most once");
-            MeterLeakDetector.deregister(ref2);
+            MeterLeakDetector.untrack(ref2);
         } finally {
-            MeterLeakDetector.deregister(ref1);
+            MeterLeakDetector.untrack(ref1);
             MeterLeakDetector.resetShutdownHookForTests();
         }
     }
@@ -217,12 +219,51 @@ class MeterLeakDetectorTest {
     @DisplayName("no shutdown hook is installed when reportLeaksOnShutdown is disabled")
     void disabledReportLeaksOnShutdownInstallsNoHook() {
         // reportLeaksOnShutdown defaults to false (restored by @ResetMeterConfig)
-        final MeterReference ref = MeterLeakDetector.register(meter);
+        final MeterReference ref = MeterLeakDetector.track(meter, null);
         try {
             assertNull(MeterLeakDetector.shutdownHookForTests(),
                     "no shutdown hook should be installed when the option is disabled");
         } finally {
-            MeterLeakDetector.deregister(ref);
+            MeterLeakDetector.untrack(ref);
         }
+    }
+
+    @Test
+    @DisplayName("track chains previousInstance and untrack returns it as the new stack top")
+    void trackChainsPreviousInstanceAndUntrackRestoresIt() {
+        final MeterReference first = MeterLeakDetector.track(meter, null);
+        final MeterReference second = MeterLeakDetector.track(meter, first);
+        try {
+            assertSame(first, MeterLeakDetector.untrack(second),
+                    "untrack must return the previous reference so the caller can restore the stack top");
+            assertNull(MeterLeakDetector.untrack(first),
+                    "untracking the bottom reference must return null (empty stack)");
+        } finally {
+            MeterLeakDetector.untrack(first);
+            MeterLeakDetector.untrack(second);
+        }
+    }
+
+    @Test
+    @DisplayName("track does not register or report when detectLeaks is disabled, but still yields a stack node")
+    void trackWithDetectLeaksDisabledCreatesPlainNode() {
+        MeterConfig.detectLeaks = false;
+        final MeterReference ref = MeterLeakDetector.track(meter, null);
+        assertNotNull(ref, "a stack node must be returned even when leak detection is off");
+        assertSame(meter, ref.get(), "the stack node must weakly reference the meter so the stack can resolve it");
+        assertEquals(0, MeterLeakDetector.trackedCount(), "a non-detecting node must not be registered");
+        MeterLeakDetector.reportRemainingLeaks();
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("track does not register the dummy '???' meter")
+    void trackExcludesUnknownCategoryMeter() {
+        lenient().when(meter.getCategory()).thenReturn(Meter.UNKNOWN_LOGGER_NAME);
+        final MeterReference ref = MeterLeakDetector.track(meter, null);
+        assertNotNull(ref, "a stack node must still be returned for the dummy meter");
+        assertEquals(0, MeterLeakDetector.trackedCount(), "the dummy '???' meter must not be registered for leaks");
+        MeterLeakDetector.reportRemainingLeaks();
+        assertNoEvents(logger);
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
@@ -153,89 +153,36 @@ class MeterLeakDetectorTest {
     }
 
     @Test
-    @DisplayName("reportRemainingLeaks should report every still-registered meter and empty the registry")
-    void reportRemainingLeaksReportsAllRegistered() {
-        MeterLeakDetector.track(meter, null);
-        MeterLeakDetector.track(meter, null);
-        assertEquals(2, MeterLeakDetector.trackedCount(), "both meters should be tracked before the sweep");
-
-        MeterLeakDetector.reportRemainingLeaks();
-
-        assertEquals(0, MeterLeakDetector.trackedCount(), "the registry must be empty after the sweep");
+    @DisplayName("drain reports an enqueued meter that is still registered, exactly once, and unlinks it")
+    void drainReportsEnqueuedRegisteredMeter() {
+        final MeterReference ref = MeterLeakDetector.track(meter, null);
+        ref.enqueue(); // simulate the garbage collector enqueueing a forgotten, never-stopped meter
+        MeterLeakDetector.drain();
+        assertEquals(0, MeterLeakDetector.trackedCount(), "the reported reference must be unlinked from the registry");
         assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
                 "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
-        assertEvent(logger, 1, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
-                "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
+        assertEquals(1, ((MockLogger) logger).getLoggerEvents().size(), "a forgotten meter must be reported exactly once");
     }
 
     @Test
-    @DisplayName("reportRemainingLeaks should be idempotent and not double-report")
-    void reportRemainingLeaksIsIdempotent() {
-        MeterLeakDetector.track(meter, null);
-        MeterLeakDetector.reportRemainingLeaks();
-        MeterLeakDetector.reportRemainingLeaks();
-        assertEquals(0, MeterLeakDetector.trackedCount(), "registry must stay empty");
-        assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
-                "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
-        assertEquals(1, ((MockLogger) logger).getLoggerEvents().size(),
-                "a forgotten meter must be reported exactly once across repeated sweeps");
-    }
-
-    @Test
-    @DisplayName("reportRemainingLeaks empties the registry but stays silent when detectLeaks is turned off at runtime")
-    void reportRemainingLeaksSuppressedWhenDetectLeaksDisabled() {
-        MeterLeakDetector.track(meter, null); // registered while detectLeaks is on (default)
-        MeterConfig.detectLeaks = false;      // turned off at runtime, after registration
-        MeterLeakDetector.reportRemainingLeaks();
-        assertEquals(0, MeterLeakDetector.trackedCount(), "the sweep must still empty the registry");
+    @DisplayName("drain stays silent when detectLeaks is turned off at runtime, but still cleans up the registry")
+    void drainSuppressedWhenDetectLeaksDisabled() {
+        final MeterReference ref = MeterLeakDetector.track(meter, null); // registered while detectLeaks is on (default)
+        MeterConfig.detectLeaks = false;                                 // turned off at runtime, after registration
+        ref.enqueue();
+        MeterLeakDetector.drain();
+        assertEquals(0, MeterLeakDetector.trackedCount(), "drain must still unlink the reference");
         assertNoEvents(logger);
     }
 
     @Test
-    @DisplayName("reportRemainingLeaks on an empty registry should be a no-op")
-    void reportRemainingLeaksEmptyIsNoOp() {
-        MeterLeakDetector.reportRemainingLeaks();
-        assertEquals(0, MeterLeakDetector.trackedCount());
-        assertNoEvents(logger);
-    }
-
-    @Test
-    @DisplayName("a deregistered meter is not reported by the shutdown sweep")
-    void deregisteredMeterIsNotReportedOnShutdownSweep() {
+    @DisplayName("drain ignores an enqueued meter that was already untracked")
+    void drainIgnoresEnqueuedUntrackedMeter() {
         final MeterReference ref = MeterLeakDetector.track(meter, null);
-        MeterLeakDetector.untrack(ref);
-        MeterLeakDetector.reportRemainingLeaks();
+        MeterLeakDetector.untrack(ref); // meter stopped before it was collected
+        ref.enqueue();
+        MeterLeakDetector.drain();
         assertNoEvents(logger);
-    }
-
-    @Test
-    @DisplayName("enabling reportLeaksOnShutdown installs a shutdown hook at most once")
-    void enablingReportLeaksOnShutdownInstallsHookOnce() {
-        MeterConfig.reportLeaksOnShutdown = true;
-        final MeterReference ref1 = MeterLeakDetector.track(meter, null);
-        try {
-            final Thread hook = MeterLeakDetector.shutdownHookForTests();
-            assertNotNull(hook, "a shutdown hook must be installed when reportLeaksOnShutdown is enabled");
-            final MeterReference ref2 = MeterLeakDetector.track(meter, null);
-            assertSame(hook, MeterLeakDetector.shutdownHookForTests(), "the hook must be installed at most once");
-            MeterLeakDetector.untrack(ref2);
-        } finally {
-            MeterLeakDetector.untrack(ref1);
-            MeterLeakDetector.resetShutdownHookForTests();
-        }
-    }
-
-    @Test
-    @DisplayName("no shutdown hook is installed when reportLeaksOnShutdown is disabled")
-    void disabledReportLeaksOnShutdownInstallsNoHook() {
-        // reportLeaksOnShutdown defaults to false (restored by @ResetMeterConfig)
-        final MeterReference ref = MeterLeakDetector.track(meter, null);
-        try {
-            assertNull(MeterLeakDetector.shutdownHookForTests(),
-                    "no shutdown hook should be installed when the option is disabled");
-        } finally {
-            MeterLeakDetector.untrack(ref);
-        }
     }
 
     @Test
@@ -262,7 +209,6 @@ class MeterLeakDetectorTest {
         assertNotNull(ref, "a stack node must be returned even when leak detection is off");
         assertSame(meter, ref.get(), "the stack node must weakly reference the meter so the stack can resolve it");
         assertEquals(0, MeterLeakDetector.trackedCount(), "a non-detecting node must not be registered");
-        MeterLeakDetector.reportRemainingLeaks();
         assertNoEvents(logger);
     }
 
@@ -273,7 +219,6 @@ class MeterLeakDetectorTest {
         final MeterReference ref = MeterLeakDetector.track(meter, null);
         assertNotNull(ref, "a stack node must still be returned for the dummy meter");
         assertEquals(0, MeterLeakDetector.trackedCount(), "the dummy '???' meter must not be registered for leaks");
-        MeterLeakDetector.reportRemainingLeaks();
         assertNoEvents(logger);
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalLegacyTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalLegacyTest.java
@@ -257,12 +257,9 @@ public class MeterThreadLocalLegacyTest {
 
         assertEquals("???", Meter.getCurrentInstance().getCategory(), "Should still be no active Meter if m1.start() was not called");
 
-        // Clean up to avoid finalize warnings if m1 is not explicitly stopped
-        // In a real scenario, an unstarted Meter wouldn't cause issues, but for testing, we ensure clean state.
-        // If m1 was started and not stopped, it would log a warning on finalize.
-        // Since it was not started, it won't be in the ThreadLocal stack, so no explicit stop is needed for ThreadLocal.
-        // However, if it were to be started later, it would need to be stopped.
-        // For this specific test, we just ensure it's not active.
+        // m1 was created but never started, so it is neither in the ThreadLocal stack nor registered with the
+        // leak detector (registration happens only in start()). No explicit stop is needed and no leak warning
+        // would ever be emitted for it.
     }
 
     /**

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalWeakReferenceGcTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalWeakReferenceGcTest.java
@@ -21,11 +21,11 @@ import org.slf4j.Logger;
 import org.slf4j.impl.MockLogger;
 import org.slf4j.impl.MockLoggerEvent;
 import org.usefultoys.slf4j.LoggerFactory;
+import org.usefultoys.test.ResetMeterConfig;
 import org.usefultoys.test.ValidateCleanMeter;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,6 +61,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * @author Daniel Felix Ferber
  */
 @ValidateCleanMeter
+@ResetMeterConfig
 @DisplayName("Diagnostic: WeakReference in Meter ThreadLocal loses the started Meter on GC")
 class MeterThreadLocalWeakReferenceGcTest {
 
@@ -92,7 +93,6 @@ class MeterThreadLocalWeakReferenceGcTest {
                 return false;
             }
             System.gc();
-            System.runFinalization();
             // Real allocation pressure: provokes collection even if System.gc() is only a hint.
             final byte[] pressure = new byte[8 * 1024 * 1024];
             blackhole += pressure.length;
@@ -109,6 +109,9 @@ class MeterThreadLocalWeakReferenceGcTest {
     @Test
     @DisplayName("A strongly referenced started Meter survives GC and stays on the stack")
     void stronglyReferencedMeterSurvivesGc() {
+        // This diagnostic targets the thread-local WeakReference stack, not leak detection; disable the
+        // detector to keep the two mechanisms isolated.
+        MeterConfig.detectLeaks = false;
         assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
 
         final Meter meter = new Meter(logger).start();
@@ -139,6 +142,9 @@ class MeterThreadLocalWeakReferenceGcTest {
     @Test
     @DisplayName("A non-referenced started Meter is lost from the stack after GC (the flake)")
     void weakReferenceLosesStartedMeterAfterGc() {
+        // This diagnostic targets the thread-local WeakReference stack, not leak detection; disable the
+        // detector so the deliberately forgotten fixture below does not enqueue a real leak report.
+        MeterConfig.detectLeaks = false;
         assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
 
         // Start a Meter but keep NO strong reference to it. This mirrors a test/operation that
@@ -165,6 +171,9 @@ class MeterThreadLocalWeakReferenceGcTest {
     @Test
     @DisplayName("An 'expected dirty' stack can appear clean after GC under WeakReference")
     void expectedDirtyStackCanAppearCleanAfterGc() {
+        // This diagnostic targets the thread-local WeakReference stack, not leak detection; disable the
+        // detector so the deliberately forgotten fixture below does not enqueue a real leak report.
+        MeterConfig.detectLeaks = false;
         assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
 
         new Meter(logger).start().inc().inc();
@@ -191,9 +200,11 @@ class MeterThreadLocalWeakReferenceGcTest {
      *       message must be emitted so the misuse is visible.</li>
      *   <li><b>Resilience:</b> the thread-local stack must self-heal back to the dummy {@code "???"}.</li>
      * </ol>
-     * This test proves that the current {@code WeakReference}-based design satisfies all three, and
-     * therefore that removing the {@code WeakReference} (which would pin the chain in a pooled thread
-     * and also prevent {@code finalize()} from ever logging) must NOT be done under this requirement.
+     * This test proves that the {@link MeterLeakDetector} (the {@code PhantomReference}-based replacement for the
+     * former {@code finalize()} mechanism) satisfies all three together with the {@code WeakReference}-based stack:
+     * the {@code WeakReference} guarantees (1) and (3), and the detector — drained here synchronously on the test
+     * thread — guarantees (2). Because draining is opportunistic and runs on the caller's thread, the warning is
+     * emitted deterministically rather than by a background finalizer thread.
      */
     @Test
     @DisplayName("REQUIREMENT: a forgotten Meter is reclaimed (no leak), logs a warning, and the stack self-heals")
@@ -206,21 +217,22 @@ class MeterThreadLocalWeakReferenceGcTest {
         messageLogger.clearEvents();
 
         // Start a Meter and "forget" it: keep NO strong reference. A WeakReference lets us observe
-        // whether it becomes collectable without itself preventing collection.
+        // whether it becomes collectable without itself preventing collection. Leak detection is on
+        // by default (restored by @ResetMeterConfig), so start() registers it with the detector.
         final WeakReference<Meter> tracker = new WeakReference<>(new Meter(logger).start());
         assertEquals(CATEGORY, Meter.getCurrentInstance().getCategory(),
                 "Meter must be active immediately after start()");
 
-        // Drive GC + finalization until the Meter is reclaimed AND its finalize() warning is logged.
-        final boolean reclaimedAndWarned = driveReclamationAndFinalization(tracker, messageLogger);
-        assumeTrue(reclaimedAndWarned, "Could not trigger GC/finalization in this environment; skipping");
+        // Drive GC until the Meter is reclaimed and the detector, drained on this thread, logs the warning.
+        final boolean reclaimedAndWarned = driveReclamationAndDrain(tracker, messageLogger);
+        assumeTrue(reclaimedAndWarned, "Could not trigger GC in this environment; skipping");
 
         // (1) NO MEMORY LEAK: nothing retained the forgotten Meter, so the GC reclaimed it.
         assertNull(tracker.get(),
-                "A forgotten started Meter must be garbage-collectable: the WeakReference design "
-                        + "guarantees no unbounded retention in a pooled thread — i.e. no memory leak.");
+                "A forgotten started Meter must be garbage-collectable: neither the WeakReference stack nor "
+                        + "the PhantomReference detector pins it — i.e. no memory leak.");
 
-        // (2) INCONSISTENCY LOGGED: finalize() reported the never-stopped Meter.
+        // (2) INCONSISTENCY LOGGED: the leak detector reported the never-stopped Meter.
         assertTrue(hasNeverStoppedWarning(messageLogger),
                 "Reclaiming a started-but-never-stopped Meter must log an inconsistency warning "
                         + "('Meter never stopped...') so the misuse is visible.");
@@ -231,21 +243,21 @@ class MeterThreadLocalWeakReferenceGcTest {
     }
 
     /**
-     * Drives garbage collection and finalization until the tracked Meter has been reclaimed AND its
-     * {@code finalize()} warning has been logged, or until the time budget expires.
+     * Drives garbage collection until the tracked Meter has been reclaimed and the {@link MeterLeakDetector},
+     * drained synchronously on this thread, has logged the never-stopped warning — or until the time budget expires.
      *
      * @return {@code true} if both reclamation and the warning were observed in time; {@code false}
-     *         if the collector/finalizer could not be driven (the test should then be skipped).
+     *         if the collector could not be driven (the test should then be skipped).
      */
-    @SuppressWarnings({"removal", "deprecation"})
-    private static boolean driveReclamationAndFinalization(
+    private static boolean driveReclamationAndDrain(
             final WeakReference<Meter> tracker, final MockLogger messageLogger) {
         final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
         while (System.nanoTime() < deadlineNanos) {
             System.gc();
-            System.runFinalization();
             final byte[] pressure = new byte[8 * 1024 * 1024];
             blackhole += pressure.length;
+            // Drain on this thread: any meter the GC enqueued is reported here, deterministically.
+            MeterLeakDetector.drain();
             if (tracker.get() == null && hasNeverStoppedWarning(messageLogger)) {
                 return true;
             }
@@ -254,21 +266,17 @@ class MeterThreadLocalWeakReferenceGcTest {
     }
 
     /**
-     * Defensively scans the logger for the finalize() inconsistency warning. Tolerates concurrent
-     * writes from the finalizer thread by snapshotting and retrying on the next poll iteration.
+     * Scans the logger for the leak detector's inconsistency warning. Draining happens on the test thread,
+     * so there is no concurrent appender to guard against.
      */
     private static boolean hasNeverStoppedWarning(final MockLogger messageLogger) {
-        try {
-            for (final MockLoggerEvent event : new ArrayList<>(messageLogger.getLoggerEvents())) {
-                final String formatted = event.getFormattedMessage();
-                if (event.getLevel() == MockLoggerEvent.Level.ERROR
-                        && formatted != null
-                        && formatted.contains("Meter never stopped")) {
-                    return true;
-                }
+        for (final MockLoggerEvent event : new ArrayList<>(messageLogger.getLoggerEvents())) {
+            final String formatted = event.getFormattedMessage();
+            if (event.getLevel() == MockLoggerEvent.Level.ERROR
+                    && formatted != null
+                    && formatted.contains("Meter never stopped")) {
+                return true;
             }
-        } catch (final ConcurrentModificationException ignored) {
-            // The finalizer thread is appending concurrently; treat as "not yet" and retry.
         }
         return false;
     }

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterValidatorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterValidatorTest.java
@@ -58,7 +58,6 @@ import static org.usefultoys.slf4jtestmock.AssertLogger.assertNoEvents;
  *   <li><b>Progress Precondition:</b> Validates meter is started before progress reporting</li>
  *   <li><b>Path Arguments:</b> Validates path arguments are not null</li>
  *   <li><b>Path Precondition:</b> Validates meter is started and not stopped before setting path</li>
- *   <li><b>Finalization:</b> Validates finalization checks for started-but-not-stopped meters</li>
  *   <li><b>Utility Methods:</b> Validates direct logging methods for invalid state, arguments, and transitions</li>
  *   <li><b>Error Logging:</b> Validates proper error logging with markers and stack traces</li>
  * </ul>
@@ -827,62 +826,6 @@ public class MeterValidatorTest {
             assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
                     "Meter.validatePathCallArgument", message, "test-id");
             assertEventWithThrowable(logger, 0, CallerStackTraceThrowable.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("Finalization Tests")
-    class FinalizationTests {
-
-        @Test
-        @DisplayName("should log error when meter is not stopped during finalization")
-        void shouldValidateFinalizeWhenNotStopped() {
-            // Given: meter has been started but not stopped (start time = 1L, stop time = 0L) and has a valid category
-            when(meter.getStartTime()).thenReturn(1L);
-            when(meter.getStopTime()).thenReturn(0L);
-            when(meter.getCategory()).thenReturn("test-category");
-            // When: validateFinalize is called
-            // Then: should log finalization error
-            MeterValidator.validateFinalize(meter);
-            assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT, "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
-        }
-
-        @Test
-        @DisplayName("should not log error when meter is already stopped")
-        void shouldValidateFinalizeWhenAlreadyStopped() {
-            // Given: meter has been started and stopped (start time = 1L, stop time = 2L)
-            when(meter.getStartTime()).thenReturn(1L);
-            when(meter.getStopTime()).thenReturn(2L);
-            // When: validateFinalize is called
-            // Then: should not log any events
-            MeterValidator.validateFinalize(meter);
-            assertNoEvents(logger);
-        }
-
-        @Test
-        @DisplayName("should not log error when meter uses unknown logger name")
-        void shouldValidateFinalizeWhenUnknownLogger() {
-            // Given: meter has been started but not stopped and uses unknown logger name
-            when(meter.getStartTime()).thenReturn(1L);
-            when(meter.getStopTime()).thenReturn(0L);
-            when(meter.getCategory()).thenReturn(Meter.UNKNOWN_LOGGER_NAME);
-            // When: validateFinalize is called
-            // Then: should not log any events (unknown logger is acceptable)
-            MeterValidator.validateFinalize(meter);
-            assertNoEvents(logger);
-        }
-
-        @Test
-        @DisplayName("should not log error when meter was never started")
-        void shouldValidateFinalizeWhenNotStarted() {
-            // Given: meter was never started (start time = 0L)
-            when(meter.getStartTime()).thenReturn(0L);
-            when(meter.getStopTime()).thenReturn(0L);
-            when(meter.getCategory()).thenReturn("test-category");
-            // When: validateFinalize is called
-            // Then: should not log any events
-            MeterValidator.validateFinalize(meter);
-            assertNoEvents(logger);
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the deprecated `Object.finalize()` mechanism in `Meter` — used to detect operations that were `start()`-ed but never explicitly stopped — with a forward-compatible detector that works on Java 8 through future releases where finalization is removed (JEP 421). Closes the work tracked in #52 and #53.

The detector is built on `WeakReference` + `ReferenceQueue` (available since Java 2), needs no multi-release JAR, **no background daemon thread, and no JVM shutdown hook**, and preserves the exact leak predicate, message, and `ERROR` level (marker `INVALID_ARGUMENT`) the former `finalize()` path emitted.

## Approach

Implemented incrementally (one concern per commit):

1. **`MeterConfig.detectLeaks`** toggle (`slf4jtoys.meter.detect.leaks`, default `true`) — the single knob governing both detection and reporting.
2. **`MeterLeakDetector`** mechanism — `WeakReference` + `ReferenceQueue` + an **intrusive doubly-linked registry** (the reference *is* the node, so no separate container allocation, mirroring `java.lang.ref.Cleaner`). Drained **opportunistically** from the next `start()` — no daemon thread.
3. **Wiring + `finalize()` removal** in one atomic commit (no double-logging window): `start()` registers, `ok()/reject()/fail()/close()` deregister; `Meter.finalize()` and `MeterValidator.validateFinalize` are removed.
4. **Single-reference unification** — the thread-local stack `WeakReference` and the leak handle are collapsed into one object, keeping allocation at **one auxiliary object per started meter** (the library's "at most one object per meter" design principle).
5. **`detectLeaks` as a runtime kill switch** — `drain()` re-reads the flag, so turning it off at runtime also suppresses reports already pending, not just future meters.

## Key design decisions

- **`WeakReference`, not `PhantomReference`**: required because the unified object also backs the thread-local stack, whose `get()` must return the live meter. It is also a better fit — the referent is reclaimed as soon as it is weakly reachable, and `reportLeak()` works from an immutable snapshot (`fullID` + message logger).
- **No background thread and no JVM shutdown hook**: a default-on shutdown hook would pin the web application class loader across redeploys in the servlet containers and application servers this library targets (Tomcat, TomEE, WebLogic, WebSphere) — the classic class-loader leak. Detection is therefore purely GC-driven; a meter forgotten but never collected before JVM exit is simply not reported (it does not leak memory, being only weakly referenced). An earlier opt-in `reportLeaksOnShutdown` tail-drain was added and then **removed** in favor of a single `detectLeaks` toggle.
- **No `start()`-predecessor check** (an alternative floated in #52): a started-but-unstopped predecessor on the stack is the *normal* state during legitimate nested meters, so that check would false-positive on nesting.

## Behavior change

- `Meter.finalize()` no longer exists. The forgotten-meter warning is now emitted by the detector when the meter is garbage-collected (and a later `start()` drains the queue). No API change for callers.

## Testing

- New `MeterLeakDetectorTest` (deterministic, no GC reliance): registry mechanics, idempotency, null-safety, stack-node chaining, non-detecting path, `"???"` exclusion, report-message contract, and **drain tests that drive the GC path via `Reference.enqueue()`** (reports a registered enqueued meter exactly once; stays silent when `detectLeaks` is off; ignores an untracked enqueued meter).
- `MeterConfigTest`: default/parse/invalid coverage for `detectLeaks`.
- `MeterThreadLocalWeakReferenceGcTest` adapted: the forgotten-meter requirement test drives GC and drains the detector **synchronously on the test thread** (deterministic; no finalizer thread, no `System.runFinalization()`); the stack diagnostics disable `detectLeaks` so their deliberately forgotten fixtures don't enqueue real leak reports.
- Removed the 4 `MeterValidatorTest` finalization tests (predicate/message now covered by `MeterLeakDetectorTest`).
- `README.md` updated with a "Leak detection" section (AGENTS.md README sync): behavior, `ERROR`-level message, `MeterConfig.detectLeaks` + system property, and the `finalize()` replacement note.

Full suite green: **3013 core tests + 75 logback tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)