### PR TITLE
feat(meter): forgotten-meter leak detector via PhantomReference (replaces finalize)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ try {
 }
 ```
 
+## Leak detection (forgotten meters)
+
+A `Meter` that is `start()`-ed but never explicitly terminated logs an `ERROR` message
+(marker `INVALID_ARGUMENT`) the next time any meter is started on any thread:
+
+```
+ERROR ... Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=...
+```
+
+Detection is purely garbage-collection driven. There is no background thread, no JVM shutdown hook,
+and no lock on the application's hot path. A started meter registers one `PhantomReference`;
+when the GC collects the meter without an explicit stop, the next `start()` call drains the reference
+queue and emits the error.
+
+> **Note:** This replaces the previous `Object.finalize()`-based detection (JEP 421).
+
+| Field | System property | Default | Description |
+|---|---|---|---|
+| `MeterConfig.detectLeaks` | `slf4jtoys.meter.detect.leaks` | `true` | Enables forgotten-meter detection. Disable in tests that deliberately leave meters open. |
+
 ## Installation
 
 *slf4j-toys* is available from the [Maven Central repository](https://search.maven.org/artifact/org.usefultoys/slf4j-toys/1.9.0/jar).

--- a/doc/TDR-0035-phantomreference-leak-detector-for-forgotten-meters.md
+++ b/doc/TDR-0035-phantomreference-leak-detector-for-forgotten-meters.md
@@ -1,0 +1,139 @@
+# TDR-0035: PhantomReference Leak Detector for Forgotten Meters
+
+**Status**: Accepted  
+**Date**: 2026-07-02
+
+## Context
+
+A `Meter` describes an operation with an explicit lifecycle: it is `start()`-ed and must be terminated by exactly one of `ok()`, `reject()`, `fail()`, or `close()`. When application code starts a meter and never terminates it — a genuine misuse — the library should surface the mistake instead of hiding it.
+
+Historically this was detected in `Object.finalize()`, which delegated to `MeterValidator.validateFinalize()`: when the JVM finalized an unreachable `Meter` that had been started but never stopped, an `ERROR` was logged. This mechanism has become untenable:
+
+- **`finalize()` is deprecated for removal** (JEP 421). Code that overrides it will eventually stop compiling and, before that, emits deprecation warnings.
+- **Finalization is pathological.** It runs on a single shared finalizer thread, is non-deterministic, delays reclamation by at least one extra GC cycle, and allows object resurrection.
+
+Replacing it is constrained by hard design principles of this library:
+
+- **The `Meter` must stay transparent to the application.** Following the non-intrusive philosophy of [TDR-0017](TDR-0017-non-intrusive-validation-and-error-handling.md), starting or stopping a meter must not acquire a library-owned lock or otherwise impose a side effect the application can observe as contention. Leak detection is a diagnostic aid; it must never become a synchronization point on the application's hot path.
+- **No memory leak.** A forgotten, started meter must remain garbage-collectable. The thread-local lifecycle stack already holds meters through `WeakReference` precisely so a forgotten meter is never pinned (see [TDR-0015](TDR-0015-threadlocal-stack-for-context-propagation.md)); the leak detector must not reintroduce a strong retention path.
+- **No background thread and no JVM shutdown hook.** A library-owned daemon thread or shutdown hook can pin a web-application class loader in servlet containers (Tomcat, TomEE, …), causing redeploy leaks.
+- **Portability from Java 8 onward**, including future JDKs where finalization is removed entirely.
+
+## Decision
+
+Detect forgotten meters with a `PhantomReference` + `ReferenceQueue`, implemented in the package-private `MeterLeakDetector`. The `Meter` owns a single handle field and calls into the detector at the lifecycle boundaries:
+
+- **On `start()`** (gated by `MeterConfig.detectLeaks` and skipping the `UNKNOWN` category), `register(this)` creates a `MeterReference` — a `PhantomReference<Meter>` that snapshots `fullID` and the message `Logger` — and adds it to a **static anchor set**.
+- **On every explicit termination** (`ok()`/`reject()`/`fail()`/`close()`), `deregister(ref)` removes the reference from the anchor and calls `ref.clear()`.
+- **Draining is opportunistic**: `register()` first calls `drain()`, on the caller's own thread. Any reference still present in the anchor when the garbage collector enqueues it is — by construction — a meter that was started and never stopped, and is reported with an `ERROR` under the `INVALID_ARGUMENT` marker (byte-for-byte equivalent to the former `finalize()` message).
+
+```java
+private static final ReferenceQueue<Meter> QUEUE = new ReferenceQueue<>();
+private static final Set<MeterReference> ANCHOR = ConcurrentHashMap.newKeySet();
+
+static MeterReference register(final Meter meter) {
+    drain();
+    final MeterReference ref = new MeterReference(meter, QUEUE);
+    ANCHOR.add(ref);      // keeps the ref reachable independently of the meter
+    return ref;
+}
+
+static void deregister(final MeterReference ref) {
+    if (ref == null) return;
+    if (ANCHOR.remove(ref)) {   // membership IS the "still registered" state
+        ref.clear();            // a stopped meter is never enqueued
+    }
+}
+
+static void drain() {
+    Reference<? extends Meter> r;
+    while ((r = QUEUE.poll()) != null) {
+        final MeterReference ref = (MeterReference) r;
+        if (ANCHOR.remove(ref)) {  // still anchored => never stopped => leak
+            ref.reportLeak();
+        }
+    }
+}
+```
+
+**The anchor set is mandatory, not bookkeeping.** The garbage collector only enqueues a `PhantomReference` whose *reference object* is itself reachable through a strong path **independent of its referent**. A `MeterReference` held only by its own `Meter` (for example, through a field on the meter) becomes unreachable at the same instant as the meter and is collected *with* it — never enqueued — so the leak would silently go unreported. The static `ConcurrentHashMap.newKeySet()` keeps every live registration reachable from a GC root independently of the meter, until the meter is either stopped (deregistered) or collected and drained.
+
+The anchor set is a `ConcurrentHashMap`-backed set, so `add`/`remove` are CAS operations on independent bins — no library-owned monitor lock. The atomic `Set.remove(Object)` also claims each reference exactly once, providing idempotency and de-duplication between concurrent drains, so no separate per-reference flag or counter is required.
+
+## Consequences
+
+### Positive ✅
+
+- **Forward-compatible**: no `finalize()` override anywhere; the mechanism relies only on `java.lang.ref`, stable since Java 2 and unaffected by JEP 421.
+- **No lock on the hot path**: `start()`/`stop()` touch a lock-free concurrent set (per-bin CAS), never a monitor. This honors the transparency principle of [TDR-0017](TDR-0017-non-intrusive-validation-and-error-handling.md).
+- **No background thread, no shutdown hook**: draining happens synchronously on whichever application thread starts the next meter, so nothing can pin a servlet container's class loader.
+- **No memory leak**: the anchor holds the tiny `MeterReference`, never the `Meter`; a forgotten meter stays collectable, consistent with the weak thread-local stack of [TDR-0015](TDR-0015-threadlocal-stack-for-context-propagation.md).
+- **Cheap in steady state**: for a correctly used meter the cost is two concurrent-set operations plus one small allocation per lifecycle, with **zero retained memory** (added on start, removed on stop). This is dwarfed by the timestamping, log-level checks, and metrics collection `start()`/`stop()` already perform.
+- **Deterministic reporting in practice**: because `drain()` runs on the next `start()` on *any* thread, a leak surfaces at the next meter activity anywhere in the application, rather than at the whim of a finalizer thread.
+
+### Negative ❌
+
+- **Reporting is not immediate**: a leak is reported only after the GC collects the meter *and* some thread subsequently starts another meter to trigger a drain. In an application that stops creating meters entirely, an outstanding leak may go unreported until the next meter starts (bounded, but not real-time).
+- **Irreducible shared state**: `register`/`deregister` mutate a process-wide set. It is lock-free, but it is not a zero-touch hot path; the transparency guarantee is "no monitor lock," not "no shared write."
+- **Per-registration snapshot cost**: `register()` calls `Meter.getFullID()`, which runs `String.format(...)`, on every `start()` even when no leak ever occurs. This is the largest avoidable cost on the happy path and could be deferred into `reportLeak()` if it ever proves significant.
+- **A subtle correctness footgun**: the design depends on the non-obvious GC reachability rule above. An earlier iteration that stored the reference only on the meter was silently broken; the requirement is now guarded by an assertion in `MeterThreadLocalWeakReferenceGcTest` that *fails* (rather than skips) if the warning is not produced.
+
+### Neutral ⚖️
+
+- **Gated by configuration**: `MeterConfig.detectLeaks` (system property `slf4jtoys.meter.detect.leaks`, default `true`) decides whether registration happens at all. When disabled, nothing is registered and `drain()` processes an empty queue.
+- **Message parity**: the emitted message and its `INVALID_ARGUMENT` marker are identical to the former `finalize()` path, so log consumers and existing expectations are unaffected.
+
+## Alternatives Considered
+
+### ❌ Keep `Object.finalize()`
+
+**Description**: Continue overriding `finalize()` to call `MeterValidator.validateFinalize()` when an unreachable, never-stopped meter is finalized.
+
+**Why rejected**: `finalize()` is deprecated for removal (JEP 421) and will eventually break compilation. Even today it is non-deterministic, runs on the shared finalizer thread, delays reclamation, and permits resurrection. It offers no advantage over a `PhantomReference` while carrying every one of finalization's liabilities.
+
+### ❌ PhantomReference registry as an intrusive linked list guarded by a lock
+
+**Description**: The first replacement for `finalize()`. Each `MeterReference` was a node in a global doubly-linked list; `start()` and every stop mutated the list under a `synchronized(LOCK)` block. The list anchored the references (so it worked correctly) and let `deregister()` unlink a stopped meter so `drain()` would skip it.
+
+**Why rejected**: it introduces a library-owned monitor lock on every `start()` and every stop. Under concurrency that lock becomes a contention point the application can observe — a side effect a diagnostic tool must never impose, directly violating the transparency principle of [TDR-0017](TDR-0017-non-intrusive-validation-and-error-handling.md). The chosen design keeps the anchor but replaces the locked list with a lock-free concurrent set.
+
+### ❌ PhantomReference stored only on the Meter (no anchor)
+
+**Description**: The most minimal design: `register()` creates the `MeterReference` and returns it to be kept in a field on the `Meter`; no static collection at all. It appears to eliminate shared state entirely.
+
+**Why rejected**: it is silently **broken**. A `PhantomReference` reachable only through its own referent is collected together with the referent and is *never* enqueued, so leaks are never reported. This was confirmed empirically — the requirement test could only ever be skipped, never satisfied. Correct enqueueing requires an anchor that keeps the reference reachable independently of the meter, which is exactly what the chosen static set provides.
+
+### ❌ Per-thread (ThreadLocal) anchor set
+
+**Description**: Replace the global concurrent set with a `ThreadLocal<Set<MeterReference>>`, so `register`/`deregister` touch only the current thread's set and incur no cross-thread contention.
+
+**Why rejected**: the `ReferenceQueue` is inherently global and `drain()` runs on an arbitrary thread — the one starting the next meter — which cannot claim a reference stored in another thread's set. Cross-thread termination (start on thread A, `ok()` on thread B) breaks deregistration, producing both false positives and a genuine leak in the origin thread's set. `ThreadLocal` state in pooled server threads is itself a classic retention hazard. The gain is marginal — `ConcurrentHashMap.newKeySet()` add/remove on distinct references hit distinct bins and contend almost never — so the correctness cost is not justified.
+
+### ❌ Background daemon thread draining the queue
+
+**Description**: The textbook `Reference` pattern: a dedicated daemon thread blocks on `ReferenceQueue.remove()` and reports leaks as references are enqueued, giving near-immediate detection.
+
+**Why rejected**: it reintroduces a library-owned thread with a lifecycle to manage and, in servlet containers, a real risk of pinning the web-application class loader on redeploy. Opportunistic draining on the calling thread achieves the diagnostic goal with no thread to own, at the cost of immediacy the use case does not need.
+
+### ❌ Auxiliary state for the test seam (`volatile registered` flag / `AtomicInteger` counter)
+
+**Description**: Intermediate iterations carried a `volatile boolean registered` on each reference and/or a static `AtomicInteger` tracking the live count, to make the detector observable from unit tests.
+
+**Why rejected**: both add work to every `start()`/`stop()` — a volatile write and/or a CAS — for the sole benefit of tests, contradicting the transparency goal. With the concurrent anchor, set membership already *is* the authoritative "still registered" state, and tests verify behavior directly through `drain()` plus log-event assertions and `Reference.enqueue()`. The auxiliary state was removed.
+
+## Implementation
+
+- [src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java](../src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java) — the detector: `QUEUE`, the `ANCHOR` set, `MeterReference`, and `register`/`deregister`/`drain`.
+- [src/main/java/org/usefultoys/slf4j/meter/Meter.java](../src/main/java/org/usefultoys/slf4j/meter/Meter.java) — holds the `leakRef` handle; `start()` registers, `commonOk()`/`reject()`/`fail()`/`close()` deregister; the former `finalize()` override was removed.
+- [src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java](../src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java) — `detectLeaks` flag, system property `slf4jtoys.meter.detect.leaks` (default `true`).
+- [src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java](../src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java) — `validateFinalize()` removed.
+- Tests: `MeterLeakDetectorTest` (deterministic register/deregister/drain behavior via `Reference.enqueue()`) and `MeterThreadLocalWeakReferenceGcTest` (end-to-end GC → enqueue → drain → `ERROR`, asserting the warning rather than assuming it).
+
+## References
+
+- [TDR-0015: ThreadLocal Stack for Context Propagation](TDR-0015-threadlocal-stack-for-context-propagation.md)
+- [TDR-0017: Non-Intrusive Validation and Error Handling](TDR-0017-non-intrusive-validation-and-error-handling.md)
+- [TDR-0019: Immutable Lifecycle Transitions](TDR-0019-immutable-lifecycle-transitions.md)
+- [TDR-0024: Try-with-Resources Lifecycle Fit and Limitations](TDR-0024-try-with-resources-lifecycle-fit-and-limitations.md)
+- [JEP 421: Deprecate Finalization for Removal](https://openjdk.org/jeps/421)
+- [java.lang.ref.PhantomReference](https://docs.oracle.com/javase/8/docs/api/java/lang/ref/PhantomReference.html)

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -508,13 +508,13 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             failPath = null;
             failMessage = null;
             rejectPath = null;
+            localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
             /* Override path if provided as parameter */
             if (pathId != null) {
                 okPath = toPath(pathId, true);
             }
-            localThreadInstance.set(previousInstance);
-            MeterLeakDetector.deregister(leakRef);
-            leakRef = null;
 
             if (messageLogger.isWarnEnabled()) { // Check warn enabled to cover info as well
                 SystemMetrics.getInstance().collectRuntimeStatus(this);

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -52,7 +52,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @see MeterConfig
  * @see Markers
  */
-@SuppressWarnings({"OverlyBroadCatchBlock", "FinalizeDeclaration"})
+@SuppressWarnings("OverlyBroadCatchBlock")
 public class Meter extends MeterData implements MeterContext<Meter>, MeterExecutor<Meter>, Closeable {
 
     /**
@@ -97,6 +97,13 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * These references form a linked list representing a stack of `Meter` instances.
      */
     private WeakReference<Meter> previousInstance;
+
+    /**
+     * Registration handle with the {@link MeterLeakDetector}, obtained on {@link #start()} when leak detection is
+     * enabled ({@link MeterConfig#detectLeaks}) and the category is known. {@code null} otherwise. Passed back to
+     * the detector on every explicit termination so this {@code Meter} is not reported as a leak.
+     */
+    private transient MeterLeakDetector.MeterReference leakRef;
 
     /**
      * Creates a new `Meter` for an operation belonging to the category derived from the logger's name.
@@ -351,6 +358,10 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
 
             lastProgressTime = startTime = collectCurrentTime();
 
+            if (MeterConfig.detectLeaks && !UNKNOWN_LOGGER_NAME.equals(getCategory())) {
+                leakRef = MeterLeakDetector.register(this);
+            }
+
             if (messageLogger.isDebugEnabled()) {
                 SystemMetrics.getInstance().collectRuntimeStatus(this);
                 SystemMetrics.getInstance().collectPlatformStatus(this);
@@ -502,6 +513,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 okPath = toPath(pathId, true);
             }
             localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
 
             if (messageLogger.isWarnEnabled()) { // Check warn enabled to cover info as well
                 SystemMetrics.getInstance().collectRuntimeStatus(this);
@@ -618,6 +631,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             failMessage = null;
             okPath = null;
             localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
             rejectPath = toPath(cause, true);
 
             if (messageLogger.isInfoEnabled()) {
@@ -664,6 +679,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             rejectPath = null;
             okPath = null;
             localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
             failPath = toPath(cause, false);
             /* Extract failure message from Throwable if applicable */
             if (cause instanceof Throwable) {
@@ -693,22 +710,6 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
     // ========================================================================
 
     /**
-     * Overrides the default `finalize()` method to detect `Meter` instances that were started but never explicitly
-     * stopped. If an unstopped `Meter` is garbage-collected, an error message is logged to indicate inconsistent API
-     * usage.
-     *
-     * @throws Throwable if an error occurs during finalization.
-     */
-    @SuppressWarnings("removal")
-    @Override
-    protected void finalize() throws Throwable {
-        MeterValidator.validateFinalize(this);
-        super.finalize();
-    }
-
-    // ========================================================================
-
-    /**
      * Implements the {@link Closeable} interface. If the `Meter` has not been explicitly stopped (via `ok()`,
      * `reject()`, or `fail()`), this method automatically marks the operation as {@code FAIL} with the path
      * {@code "try-with-resources"}. This ensures that no operation goes untracked when used in a `try-with-resources`
@@ -731,6 +732,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             rejectPath = null;
             okPath = null;
             localThreadInstance.set(previousInstance);
+            MeterLeakDetector.deregister(leakRef);
+            leakRef = null;
             failPath = FAIL_PATH_TRY_WITH_RESOURCES;
 
             if (messageLogger.isErrorEnabled()) {

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -62,6 +62,8 @@ public class MeterConfig {
     public final String PROP_PRINT_POSITION = "slf4jtoys.meter.print.position";
     /** System property key for enabling/disabling status printing in readable messages. */
     public final String PROP_PRINT_STATUS = "slf4jtoys.meter.print.status";
+    /** System property key for enabling/disabling the forgotten-meter leak detector. */
+    public final String PROP_DETECT_LEAKS = "slf4jtoys.meter.detect.leaks";
 
     static {
         init();
@@ -115,6 +117,21 @@ public class MeterConfig {
      * Can be assigned a new value at runtime.
      */
     public boolean printMemory;
+
+    /**
+     * Whether the {@link Meter} activates the forgotten-meter leak detector.
+     * <p>
+     * When {@code true}, a {@link Meter} that is started but never explicitly stopped ({@code ok()},
+     * {@code reject()}, {@code fail()}, or {@code close()}) will emit an error log message when it
+     * becomes eligible for garbage collection.
+     * <p>
+     * Disable this flag in test environments where meters are intentionally left open, or when the
+     * overhead of registering each started meter is undesirable.
+     * <p>
+     * Value is read from system property {@code slf4jtoys.meter.detect.leaks}, defaulting to {@code true}.
+     * Can be assigned a new value at runtime.
+     */
+    public boolean detectLeaks;
 
     /**
      * A prefix added to the logger name used for machine-parsable data messages.
@@ -179,6 +196,7 @@ public class MeterConfig {
         printPosition = ConfigParser.getProperty(PROP_PRINT_POSITION, false);
         printLoad = ConfigParser.getProperty(PROP_PRINT_LOAD, false);
         printMemory = ConfigParser.getProperty(PROP_PRINT_MEMORY, false);
+        detectLeaks = ConfigParser.getProperty(PROP_DETECT_LEAKS, true);
         dataPrefix = ConfigParser.getProperty(PROP_DATA_PREFIX, "");
         dataSuffix = ConfigParser.getProperty(PROP_DATA_SUFFIX, "");
         messagePrefix = ConfigParser.getProperty(PROP_MESSAGE_PREFIX, "");
@@ -196,6 +214,7 @@ public class MeterConfig {
         System.clearProperty(PROP_PRINT_POSITION);
         System.clearProperty(PROP_PRINT_LOAD);
         System.clearProperty(PROP_PRINT_MEMORY);
+        System.clearProperty(PROP_DETECT_LEAKS);
         System.clearProperty(PROP_DATA_PREFIX);
         System.clearProperty(PROP_DATA_SUFFIX);
         System.clearProperty(PROP_MESSAGE_PREFIX);

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterLeakDetector.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.slf4j.Logger;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Forward-compatible detector for {@link Meter} instances that were started but never explicitly stopped
+ * (via {@code ok()}, {@code reject()}, {@code fail()} or {@code close()}).
+ * <p>
+ * This is the replacement for the deprecated {@link Object#finalize()} mechanism. It relies on
+ * {@link PhantomReference} plus a {@link ReferenceQueue} — an API available on every Java version since Java 2 —
+ * so it keeps working on Java 8 through future releases where finalization is removed.
+ * <p>
+ * <b>Why the anchor set is mandatory:</b> the garbage collector only enqueues a {@link PhantomReference} whose
+ * <em>reference object</em> is itself reachable through a strong path that is independent of its referent. A
+ * {@code MeterReference} held only by its own {@code Meter} (e.g. through a field on the meter) is collected
+ * together with that meter and is <em>never</em> enqueued — so the leak would go unreported. {@link #ANCHOR}
+ * keeps every live registration strongly reachable from a GC root, independently of the meter, until the meter
+ * is either stopped (deregistered) or collected and drained.
+ * <p>
+ * <b>Design — no monitor on the hot path:</b> the anchor is a {@link ConcurrentHashMap#newKeySet() concurrent set},
+ * so {@code register}/{@code deregister}/{@code drain} mutate it with CAS operations, never a library-owned
+ * monitor lock. The atomic {@link Set#remove(Object)} also provides idempotency and de-duplication between
+ * concurrent drains, so no separate {@code registered} flag is needed.
+ * <p>
+ * When a meter is stopped explicitly, {@link #deregister} both removes it from the anchor and calls
+ * {@link MeterReference#clear()} — the latter prevents the GC from ever enqueueing a properly-stopped meter,
+ * so {@link #drain()} never even sees it.
+ * <p>
+ * <b>Draining strategy — no background thread:</b> the {@link ReferenceQueue} is drained opportunistically
+ * from {@link #register(Meter)}, i.e. on the thread that starts the next meter. A forgotten meter is
+ * reported the next time any meter is started, with no library-owned daemon thread and no risk of pinning
+ * a web application class loader in a servlet container.
+ * <p>
+ * <b>Predicate equivalence:</b> a meter is registered only from {@code start()} and is deregistered on
+ * every explicit termination. A reference still anchored when it is enqueued is, by definition, a meter that
+ * was started and never stopped — exactly the predicate the former {@code finalize()} path checked.
+ *
+ * @author Daniel Felix Ferber
+ * @see Meter
+ * @see MeterConfig#detectLeaks
+ */
+final class MeterLeakDetector {
+
+    private MeterLeakDetector() {
+        // Utility holder, not instantiable.
+    }
+
+    /** Queue onto which the garbage collector enqueues references whose meters became unreachable. */
+    private static final ReferenceQueue<Meter> QUEUE = new ReferenceQueue<>();
+
+    /**
+     * Strongly holds every live registration, independently of the meter it points to. Without this anchor
+     * a {@link MeterReference} reachable only through its own referent would be collected together with the
+     * meter and never enqueued. Membership is the authoritative "still registered" state: {@link #deregister}
+     * and {@link #drain} both use the atomic {@link Set#remove(Object)} to claim a reference exactly once.
+     */
+    private static final Set<MeterReference> ANCHOR = ConcurrentHashMap.newKeySet();
+
+    /**
+     * A {@link PhantomReference} to a started {@link Meter} that snapshots the data required to report
+     * a leak after the referent has been collected.
+     */
+    static final class MeterReference extends PhantomReference<Meter> {
+        private final String fullID;
+        private final Logger messageLogger;
+
+        MeterReference(final Meter meter, final ReferenceQueue<Meter> queue) {
+            super(meter, queue);
+            this.fullID = meter.getFullID();
+            this.messageLogger = meter.getMessageLogger();
+        }
+
+        /**
+         * Emits the forgotten-meter error, byte-for-byte equivalent to the former
+         * {@code MeterValidator.validateFinalize}.
+         */
+        void reportLeak() {
+            messageLogger.error(Markers.INVALID_ARGUMENT,
+                    "{}; id={}",
+                    "Meter never stopped, must remember to call ok/reject/fail/success() on each started one",
+                    fullID);
+        }
+    }
+
+    /**
+     * Registers a started meter for leak detection. Drains pending leaks first (opportunistic).
+     * The returned handle must be passed to {@link #deregister(MeterReference)} when the meter is stopped.
+     *
+     * @param meter the meter that has just been started; must not be {@code null}.
+     * @return the registration handle to retain and pass to {@link #deregister(MeterReference)}.
+     */
+    static MeterReference register(final Meter meter) {
+        drain();
+        final MeterReference ref = new MeterReference(meter, QUEUE);
+        ANCHOR.add(ref);
+        return ref;
+    }
+
+    /**
+     * Deregisters a meter that was stopped explicitly, so its eventual collection is never reported as a leak.
+     * Idempotent and {@code null}-safe. Removing the reference from {@link #ANCHOR} drops the independent
+     * strong path, and {@link MeterReference#clear()} prevents the GC from enqueueing it in the first place.
+     *
+     * @param ref the handle returned by {@link #register(Meter)}, or {@code null}.
+     */
+    static void deregister(final MeterReference ref) {
+        if (ref == null) {
+            return;
+        }
+        if (ANCHOR.remove(ref)) {
+            ref.clear();
+        }
+    }
+
+    /**
+     * Drains the reference queue and reports every meter that was collected while still registered.
+     * Lock-free; safe to call from any thread. Invoked opportunistically by {@link #register(Meter)}.
+     */
+    static void drain() {
+        Reference<? extends Meter> r;
+        while ((r = QUEUE.poll()) != null) {
+            final MeterReference ref = (MeterReference) r;
+            if (ANCHOR.remove(ref)) {
+                ref.reportLeak();
+            }
+        }
+    }
+}

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
@@ -328,20 +328,6 @@ public class MeterValidator {
     }
 
 
-    /* ========== Validate Finalize Method ========== */
-
-    /**
-     * Validates the state of a Meter instance during finalization.
-     * Logs an error if a Meter was started but never explicitly stopped.
-     *
-     * @param meter The Meter instance being finalized.
-     */
-    void validateFinalize(final Meter meter) {
-        if (meter.getStartTime() != 0 && meter.getStopTime() == 0 && !meter.getCategory().equals(Meter.UNKNOWN_LOGGER_NAME)) {
-            meter.getMessageLogger().error(Markers.INVALID_ARGUMENT, "{}; id={}", "Meter never stopped, must remember to call ok/reject/fail/success() on each started one", meter.getFullID());
-        }
-    }
-
     /* ========== Utility Methods ========== */
 
     void logInvalidStateAlreadyStopped(final Meter meter) {

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
@@ -61,6 +61,7 @@ class MeterConfigTest {
         assertFalse(MeterConfig.printPosition, "Default value for printPosition should be false");
         assertFalse(MeterConfig.printLoad, "Default value for printLoad should be false");
         assertFalse(MeterConfig.printMemory, "Default value for printMemory should be false");
+        assertTrue(MeterConfig.detectLeaks, "Default value for detectLeaks should be true");
         assertEquals("", MeterConfig.dataPrefix, "Default value for dataPrefix should be an empty string");
         assertEquals("", MeterConfig.dataSuffix, "Default value for dataSuffix should be an empty string");
         assertEquals("", MeterConfig.messagePrefix, "Default value for messagePrefix should be an empty string");
@@ -81,6 +82,7 @@ class MeterConfigTest {
         assertFalse(MeterConfig.printPosition, "Default value for printPosition should be false");
         assertFalse(MeterConfig.printLoad, "Default value for printLoad should be false");
         assertFalse(MeterConfig.printMemory, "Default value for printMemory should be false");
+        assertTrue(MeterConfig.detectLeaks, "Default value for detectLeaks should be true");
         assertEquals("", MeterConfig.dataPrefix, "Default value for dataPrefix should be an empty string");
         assertEquals("", MeterConfig.dataSuffix, "Default value for dataSuffix should be an empty string");
         assertEquals("", MeterConfig.messagePrefix, "Default value for messagePrefix should be an empty string");
@@ -88,6 +90,32 @@ class MeterConfigTest {
         assertTrue(ConfigParser.isInitializationOK(), "No errors should be reported after reset");
     }
 
+
+    /**
+     * Tests that detectLeaks property is correctly parsed from system property.
+     */
+    @Test
+    @DisplayName("should parse detectLeaks property correctly")
+    void testDetectLeaksProperty() {
+        System.setProperty(MeterConfig.PROP_DETECT_LEAKS, "false");
+        MeterConfig.init();
+        assertFalse(MeterConfig.detectLeaks, "detectLeaks should reflect the system property value");
+        assertTrue(ConfigParser.isInitializationOK(), "No errors should be reported for valid detectLeaks");
+    }
+
+    /**
+     * Tests that invalid detectLeaks property falls back to default and reports error.
+     */
+    @Test
+    @DisplayName("should handle invalid detectLeaks format")
+    void testDetectLeaksInvalidFormat() {
+        System.setProperty(MeterConfig.PROP_DETECT_LEAKS, "invalid");
+        MeterConfig.init();
+        assertTrue(MeterConfig.detectLeaks, "detectLeaks should fall back to default for invalid format");
+        assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid detectLeaks format");
+        assertEquals(1, ConfigParser.initializationErrors.size());
+        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_DETECT_LEAKS));
+    }
 
     /**
      * Tests that progressPeriodMilliseconds property is correctly parsed from system property.

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLeakDetectorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.impl.MockLoggerEvent;
+import org.usefultoys.slf4j.meter.MeterLeakDetector.MeterReference;
+import org.usefultoys.slf4jtestmock.Slf4jMock;
+import org.usefultoys.slf4jtestmock.WithMockLogger;
+import org.usefultoys.test.ResetMeterConfig;
+import org.usefultoys.test.ValidateCharset;
+import org.usefultoys.test.ValidateCleanMeter;
+
+import java.lang.ref.ReferenceQueue;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.lenient;
+import static org.usefultoys.slf4jtestmock.AssertLogger.assertEvent;
+import static org.usefultoys.slf4jtestmock.AssertLogger.assertNoEvents;
+
+/**
+ * Unit tests for {@link MeterLeakDetector}.
+ * <p>
+ * These tests exercise the detector's logic deterministically, without relying on garbage collection.
+ * Instead of a counter-based test seam (which would add overhead to production code), behavior is verified
+ * through the observable output of {@link MeterReference#reportLeak()} and the deterministic
+ * {@link java.lang.ref.Reference#enqueue()} API.
+ * <ul>
+ *   <li><b>Registration:</b> {@code register} returns a non-null handle; no side-effects are emitted.</li>
+ *   <li><b>Deregistration:</b> after {@code deregister}, an explicitly enqueued reference is silently
+ *       skipped by {@code drain()}: {@code deregister} removes it from the detector's anchor set (and calls
+ *       {@link MeterReference#clear()}), so {@code drain} no longer claims it.</li>
+ *   <li><b>Null safety:</b> {@code deregister(null)} is a no-op.</li>
+ *   <li><b>Idempotency:</b> double {@code deregister} does not cause extra reports.</li>
+ *   <li><b>Report contract:</b> {@link MeterReference#reportLeak()} emits the exact message and marker
+ *       formerly produced by {@code MeterValidator.validateFinalize}.</li>
+ * </ul>
+ * The end-to-end garbage-collection path (collection → enqueue → {@code drain} → report) is covered by
+ * {@code MeterThreadLocalWeakReferenceGcTest}.
+ */
+@ValidateCharset
+@ResetMeterConfig
+@WithMockLogger
+@ValidateCleanMeter
+class MeterLeakDetectorTest {
+
+    @Mock
+    protected Meter meter;
+
+    @Slf4jMock
+    protected Logger logger;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        lenient().when(meter.getMessageLogger()).thenReturn(logger);
+        lenient().when(meter.getFullID()).thenReturn("test-id");
+    }
+
+    @Test
+    @DisplayName("register should return a non-null handle without emitting events")
+    void registerReturnsNonNullHandle() {
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        assertNotNull(ref, "register should return a non-null handle");
+        assertNoEvents(logger);
+        MeterLeakDetector.deregister(ref);
+    }
+
+    @Test
+    @DisplayName("deregister should prevent the reference from being reported by drain")
+    void deregisterStopsReporting() {
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        MeterLeakDetector.deregister(ref);
+        ref.enqueue();
+        MeterLeakDetector.drain();
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("deregister should be idempotent: double deregister emits no extra reports")
+    void deregisterIsIdempotent() {
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        MeterLeakDetector.deregister(ref);
+        MeterLeakDetector.deregister(ref);
+        ref.enqueue();
+        MeterLeakDetector.drain();
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("deregister should tolerate a null handle")
+    void deregisterToleratesNull() {
+        MeterLeakDetector.deregister(null);
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("drain on an empty queue should be a no-op")
+    void drainEmptyQueueIsNoOp() {
+        MeterLeakDetector.drain();
+        assertNoEvents(logger);
+    }
+
+    @Test
+    @DisplayName("reportLeak should emit the forgotten-meter error from the captured snapshot")
+    void reportLeakEmitsForgottenMeterError() {
+        final MeterReference ref = new MeterReference(meter, new ReferenceQueue<Meter>());
+        ref.reportLeak();
+        assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
+                "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
+    }
+
+    @Test
+    @DisplayName("drain should report a registered reference that was manually enqueued")
+    void drainReportsEnqueuedRegisteredMeter() {
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        ref.enqueue();
+        MeterLeakDetector.drain();
+        assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
+                "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
+    }
+
+    @Test
+    @DisplayName("drain should silently skip a reference that was already deregistered")
+    void drainIgnoresEnqueuedDeregisteredMeter() {
+        final MeterReference ref = MeterLeakDetector.register(meter);
+        MeterLeakDetector.deregister(ref);
+        ref.enqueue();
+        MeterLeakDetector.drain();
+        assertNoEvents(logger);
+    }
+
+}

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalLegacyTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalLegacyTest.java
@@ -257,12 +257,8 @@ public class MeterThreadLocalLegacyTest {
 
         assertEquals("???", Meter.getCurrentInstance().getCategory(), "Should still be no active Meter if m1.start() was not called");
 
-        // Clean up to avoid finalize warnings if m1 is not explicitly stopped
-        // In a real scenario, an unstarted Meter wouldn't cause issues, but for testing, we ensure clean state.
-        // If m1 was started and not stopped, it would log a warning on finalize.
-        // Since it was not started, it won't be in the ThreadLocal stack, so no explicit stop is needed for ThreadLocal.
-        // However, if it were to be started later, it would need to be stopped.
-        // For this specific test, we just ensure it's not active.
+        // m1 was created but never started, so neither in the ThreadLocal stack nor registered with the leak detector.
+        // No explicit stop is needed.
     }
 
     /**

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalWeakReferenceGcTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalWeakReferenceGcTest.java
@@ -21,11 +21,11 @@ import org.slf4j.Logger;
 import org.slf4j.impl.MockLogger;
 import org.slf4j.impl.MockLoggerEvent;
 import org.usefultoys.slf4j.LoggerFactory;
+import org.usefultoys.test.ResetMeterConfig;
 import org.usefultoys.test.ValidateCleanMeter;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @author Daniel Felix Ferber
  */
+@ResetMeterConfig
 @ValidateCleanMeter
 @DisplayName("Diagnostic: WeakReference in Meter ThreadLocal loses the started Meter on GC")
 class MeterThreadLocalWeakReferenceGcTest {
@@ -92,7 +93,6 @@ class MeterThreadLocalWeakReferenceGcTest {
                 return false;
             }
             System.gc();
-            System.runFinalization();
             // Real allocation pressure: provokes collection even if System.gc() is only a hint.
             final byte[] pressure = new byte[8 * 1024 * 1024];
             blackhole += pressure.length;
@@ -109,6 +109,7 @@ class MeterThreadLocalWeakReferenceGcTest {
     @Test
     @DisplayName("A strongly referenced started Meter survives GC and stays on the stack")
     void stronglyReferencedMeterSurvivesGc() {
+        MeterConfig.detectLeaks = false; // deliberately forgotten fixture must not emit real leak reports
         assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
 
         final Meter meter = new Meter(logger).start();
@@ -139,6 +140,7 @@ class MeterThreadLocalWeakReferenceGcTest {
     @Test
     @DisplayName("A non-referenced started Meter is lost from the stack after GC (the flake)")
     void weakReferenceLosesStartedMeterAfterGc() {
+        MeterConfig.detectLeaks = false; // deliberately forgotten fixture must not emit real leak reports
         assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
 
         // Start a Meter but keep NO strong reference to it. This mirrors a test/operation that
@@ -165,6 +167,7 @@ class MeterThreadLocalWeakReferenceGcTest {
     @Test
     @DisplayName("An 'expected dirty' stack can appear clean after GC under WeakReference")
     void expectedDirtyStackCanAppearCleanAfterGc() {
+        MeterConfig.detectLeaks = false; // deliberately forgotten fixture must not emit real leak reports
         assertEquals(UNKNOWN, Meter.getCurrentInstance().getCategory(), "Precondition: stack must be clean");
 
         new Meter(logger).start().inc().inc();
@@ -191,9 +194,11 @@ class MeterThreadLocalWeakReferenceGcTest {
      *       message must be emitted so the misuse is visible.</li>
      *   <li><b>Resilience:</b> the thread-local stack must self-heal back to the dummy {@code "???"}.</li>
      * </ol>
-     * This test proves that the current {@code WeakReference}-based design satisfies all three, and
-     * therefore that removing the {@code WeakReference} (which would pin the chain in a pooled thread
-     * and also prevent {@code finalize()} from ever logging) must NOT be done under this requirement.
+     * This test proves that the current {@code WeakReference}-based design satisfies all three together
+     * with the {@link MeterLeakDetector}: the {@code WeakReference} guarantees (1) and (3), and the
+     * detector — drained here synchronously on the test thread — guarantees (2). Because draining is
+     * opportunistic and runs on the caller's thread, the warning is emitted deterministically rather
+     * than by a background finalizer thread.
      */
     @Test
     @DisplayName("REQUIREMENT: a forgotten Meter is reclaimed (no leak), logs a warning, and the stack self-heals")
@@ -211,16 +216,19 @@ class MeterThreadLocalWeakReferenceGcTest {
         assertEquals(CATEGORY, Meter.getCurrentInstance().getCategory(),
                 "Meter must be active immediately after start()");
 
-        // Drive GC + finalization until the Meter is reclaimed AND its finalize() warning is logged.
-        final boolean reclaimedAndWarned = driveReclamationAndFinalization(tracker, messageLogger);
-        assumeTrue(reclaimedAndWarned, "Could not trigger GC/finalization in this environment; skipping");
+        // Drive GC until the forgotten Meter is actually reclaimed. Only the ability to trigger GC is an
+        // environmental assumption; the presence of the warning afterwards is a hard requirement asserted below.
+        final boolean reclaimed = driveReclamationAndDrain(tracker, messageLogger);
+        assumeTrue(reclaimed, "Could not trigger GC to reclaim the forgotten Meter in this environment; skipping");
 
         // (1) NO MEMORY LEAK: nothing retained the forgotten Meter, so the GC reclaimed it.
         assertNull(tracker.get(),
                 "A forgotten started Meter must be garbage-collectable: the WeakReference design "
                         + "guarantees no unbounded retention in a pooled thread — i.e. no memory leak.");
 
-        // (2) INCONSISTENCY LOGGED: finalize() reported the never-stopped Meter.
+        // (2) INCONSISTENCY LOGGED: MeterLeakDetector must report the never-stopped Meter. This is asserted,
+        // not assumed: if the reference were held only by its own referent it would never be enqueued, and
+        // this assertion — not a silent skip — is what catches that regression.
         assertTrue(hasNeverStoppedWarning(messageLogger),
                 "Reclaiming a started-but-never-stopped Meter must log an inconsistency warning "
                         + "('Meter never stopped...') so the misuse is visible.");
@@ -231,22 +239,33 @@ class MeterThreadLocalWeakReferenceGcTest {
     }
 
     /**
-     * Drives garbage collection and finalization until the tracked Meter has been reclaimed AND its
-     * {@code finalize()} warning has been logged, or until the time budget expires.
+     * Drives garbage collection until the tracked Meter has been reclaimed, draining the
+     * {@link MeterLeakDetector} synchronously on this thread on every spin. Once the referent is reclaimed it
+     * keeps draining for a short grace window, because the GC may enqueue the {@link java.lang.ref.PhantomReference}
+     * a cycle or two after clearing the referent.
+     * <p>
+     * Reclamation is the only environmental precondition reported here (via the return value). Whether the
+     * never-stopped warning was actually produced is a hard requirement asserted by the caller, not swallowed here.
      *
-     * @return {@code true} if both reclamation and the warning were observed in time; {@code false}
-     *         if the collector/finalizer could not be driven (the test should then be skipped).
+     * @return {@code true} if the Meter was reclaimed within the time budget; {@code false} if the collector
+     *         could not be driven (the test should then be skipped, not failed).
      */
-    @SuppressWarnings({"removal", "deprecation"})
-    private static boolean driveReclamationAndFinalization(
+    private static boolean driveReclamationAndDrain(
             final WeakReference<Meter> tracker, final MockLogger messageLogger) {
         final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
         while (System.nanoTime() < deadlineNanos) {
             System.gc();
-            System.runFinalization();
             final byte[] pressure = new byte[8 * 1024 * 1024];
             blackhole += pressure.length;
-            if (tracker.get() == null && hasNeverStoppedWarning(messageLogger)) {
+            MeterLeakDetector.drain();
+            if (tracker.get() == null) {
+                // Referent reclaimed. Give the reference a brief window to be enqueued and drained.
+                final long graceNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+                while (!hasNeverStoppedWarning(messageLogger) && System.nanoTime() < graceNanos) {
+                    System.gc();
+                    blackhole += new byte[8 * 1024 * 1024].length;
+                    MeterLeakDetector.drain();
+                }
                 return true;
             }
         }
@@ -254,21 +273,16 @@ class MeterThreadLocalWeakReferenceGcTest {
     }
 
     /**
-     * Defensively scans the logger for the finalize() inconsistency warning. Tolerates concurrent
-     * writes from the finalizer thread by snapshotting and retrying on the next poll iteration.
+     * Scans the logger for the {@link MeterLeakDetector} inconsistency warning.
      */
     private static boolean hasNeverStoppedWarning(final MockLogger messageLogger) {
-        try {
-            for (final MockLoggerEvent event : new ArrayList<>(messageLogger.getLoggerEvents())) {
-                final String formatted = event.getFormattedMessage();
-                if (event.getLevel() == MockLoggerEvent.Level.ERROR
-                        && formatted != null
-                        && formatted.contains("Meter never stopped")) {
-                    return true;
-                }
+        for (final MockLoggerEvent event : new ArrayList<>(messageLogger.getLoggerEvents())) {
+            final String formatted = event.getFormattedMessage();
+            if (event.getLevel() == MockLoggerEvent.Level.ERROR
+                    && formatted != null
+                    && formatted.contains("Meter never stopped")) {
+                return true;
             }
-        } catch (final ConcurrentModificationException ignored) {
-            // The finalizer thread is appending concurrently; treat as "not yet" and retry.
         }
         return false;
     }

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterValidatorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterValidatorTest.java
@@ -831,62 +831,6 @@ public class MeterValidatorTest {
     }
 
     @Nested
-    @DisplayName("Finalization Tests")
-    class FinalizationTests {
-
-        @Test
-        @DisplayName("should log error when meter is not stopped during finalization")
-        void shouldValidateFinalizeWhenNotStopped() {
-            // Given: meter has been started but not stopped (start time = 1L, stop time = 0L) and has a valid category
-            when(meter.getStartTime()).thenReturn(1L);
-            when(meter.getStopTime()).thenReturn(0L);
-            when(meter.getCategory()).thenReturn("test-category");
-            // When: validateFinalize is called
-            // Then: should log finalization error
-            MeterValidator.validateFinalize(meter);
-            assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT, "Meter never stopped, must remember to call ok/reject/fail/success() on each started one; id=test-id");
-        }
-
-        @Test
-        @DisplayName("should not log error when meter is already stopped")
-        void shouldValidateFinalizeWhenAlreadyStopped() {
-            // Given: meter has been started and stopped (start time = 1L, stop time = 2L)
-            when(meter.getStartTime()).thenReturn(1L);
-            when(meter.getStopTime()).thenReturn(2L);
-            // When: validateFinalize is called
-            // Then: should not log any events
-            MeterValidator.validateFinalize(meter);
-            assertNoEvents(logger);
-        }
-
-        @Test
-        @DisplayName("should not log error when meter uses unknown logger name")
-        void shouldValidateFinalizeWhenUnknownLogger() {
-            // Given: meter has been started but not stopped and uses unknown logger name
-            when(meter.getStartTime()).thenReturn(1L);
-            when(meter.getStopTime()).thenReturn(0L);
-            when(meter.getCategory()).thenReturn(Meter.UNKNOWN_LOGGER_NAME);
-            // When: validateFinalize is called
-            // Then: should not log any events (unknown logger is acceptable)
-            MeterValidator.validateFinalize(meter);
-            assertNoEvents(logger);
-        }
-
-        @Test
-        @DisplayName("should not log error when meter was never started")
-        void shouldValidateFinalizeWhenNotStarted() {
-            // Given: meter was never started (start time = 0L)
-            when(meter.getStartTime()).thenReturn(0L);
-            when(meter.getStopTime()).thenReturn(0L);
-            when(meter.getCategory()).thenReturn("test-category");
-            // When: validateFinalize is called
-            // Then: should not log any events
-            MeterValidator.validateFinalize(meter);
-            assertNoEvents(logger);
-        }
-    }
-
-    @Nested
     @DisplayName("Utility Methods Tests")
     class UtilityMethodsTests {
 


### PR DESCRIPTION
## Summary

Replaces the deprecated `Object.finalize()`-based forgotten-meter detection (JEP 421) with a lock-free `PhantomReference` + `ReferenceQueue` mechanism, keeping the `Meter` transparent to the application: no library-owned lock on `start()`/stop, no background thread, and no JVM shutdown hook.

A `Meter` that is `start()`-ed but never terminated (`ok()`/`reject()`/`fail()`/`close()`) is reported with an `ERROR` (marker `INVALID_ARGUMENT`) — the same message the old `finalize()` path produced — the next time any meter is started on any thread.

## How it works

- `MeterLeakDetector` holds a static `ReferenceQueue` plus a `ConcurrentHashMap.newKeySet()` **anchor set**.
- `start()` → `register()` snapshots `fullID` + logger into a `MeterReference` (a `PhantomReference<Meter>`) and adds it to the anchor.
- stop → `deregister()` removes it from the anchor and calls `ref.clear()`.
- `register()` first calls `drain()` opportunistically on the caller's thread; any reference still anchored when the GC enqueues it is a leak and gets reported.

**Why the anchor is mandatory:** a `PhantomReference` reachable only through its own referent is collected together with it and never enqueued — an earlier iteration that stored the reference only on the `Meter` was silently broken. The static anchor keeps each reference reachable from a GC root independently of the meter.

Gated by `MeterConfig.detectLeaks` (system property `slf4jtoys.meter.detect.leaks`, default `true`).

## Changes

- **New** `MeterLeakDetector` + unit tests (`MeterLeakDetectorTest`).
- Wire into `Meter.start()` / `commonOk()` / `reject()` / `fail()` / `close()`; remove the `finalize()` override.
- Remove `MeterValidator.validateFinalize()` and its tests.
- `MeterThreadLocalWeakReferenceGcTest` drives reclamation via `MeterLeakDetector.drain()` and now **asserts** the warning (instead of assuming it), so a non-enqueued reference fails loudly rather than skipping silently.
- README: new "Leak detection" section.
- **TDR-0035** documenting the decision and the rejected alternatives (finalize, lock-guarded intrusive list, reference-on-meter-only, ThreadLocal anchor, background daemon thread, auxiliary test-only state).

## Testing

Full suite green: **3008 tests, 0 failures, 0 skipped** (`./mvnw test`). The forgotten-meter requirement test now passes deterministically instead of being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
