### PR TITLE
Validate minValue <= maxValue in ConfigParser.getRangeProperty

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java
@@ -38,6 +38,7 @@ import java.util.List;
  * not designed for reuse in other purposes.
  *
  * @author Daniel Felix Ferber
+ * @author Co-authored-by: GitHub Copilot using OpenCode Go / Kimi K2.7 Code
  */
 @UtilityClass
 public class ConfigParser {
@@ -128,17 +129,23 @@ public class ConfigParser {
      * If the property is not set or cannot be parsed as an integer, the default value is returned and an error
      * is recorded. If the property is set to a valid integer that is below the allowed minimum, the minimum value
      * is returned and an error is recorded. If it is above the allowed maximum, the maximum value is returned and
-     * an error is recorded.
+     * an error is recorded. If the minimum value is greater than the maximum value, the default value is returned
+     * and an error is recorded.
      *
      * @param name         the name of the system property
      * @param defaultValue the default value to return if the property is not set or cannot be parsed
      * @param minValue     the minimum value that is allowed
      * @param maxValue     the maximum value that is allowed
-     * @return the property value as an integer; the default value if the property is not set or invalid;
-     *         the minimum or maximum value if the parsed value is out of range
+     * @return the property value as an integer; the default value if the property is not set, invalid, or if the
+     *         range is invalid; the minimum or maximum value if the parsed value is out of range
      */
     public int getRangeProperty(final String name, final int defaultValue,
                                 final int minValue, final int maxValue) {
+        /* Reject invalid ranges to avoid silently confusing clamping behavior */
+        if (minValue > maxValue) {
+            initializationErrors.add("Invalid range for property '" + name + "': minValue (" + minValue + ") is greater than maxValue (" + maxValue + "). Using default value '" + defaultValue + "'.");
+            return defaultValue;
+        }
         final String value = System.getProperty(name);
         if (value == null) {
             return defaultValue;

--- a/src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java
@@ -28,6 +28,14 @@ import java.util.List;
  * {@code long}, and include additional logic for parsing time-based values with unit suffixes (e.g., "10s", "5min").
  * <p>
  * This class is not meant to be instantiated.
+ * <p>
+ * <strong>Security note regarding CWE-209 (Information Exposure Through Error Message):</strong>
+ * Error messages recorded in {@link #initializationErrors} include the raw property value to aid debugging.
+ * This is accepted by design and is not considered a CWE-209 vulnerability. This class is used solely to
+ * obtain configuration defined in {@link org.usefultoys.slf4j.SessionConfig},
+ * {@link org.usefultoys.slf4j.report.ReporterConfig}, {@link org.usefultoys.slf4j.watcher.WatcherConfig},
+ * and {@link org.usefultoys.slf4j.SystemConfig}, none of which involve sensitive values. This parser was
+ * not designed for reuse in other purposes.
  *
  * @author Daniel Felix Ferber
  */

--- a/src/test/java/org/usefultoys/slf4j/utils/ConfigParserTest.java
+++ b/src/test/java/org/usefultoys/slf4j/utils/ConfigParserTest.java
@@ -248,6 +248,44 @@ class ConfigParserTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"10", "100", "-5"})
+    @DisplayName("should return default and report error when range is inverted")
+    void shouldReturnDefaultAndReportErrorWhenRangeIsInverted(final String input) {
+        // Given: system property set with inverted range (min > max)
+        System.setProperty("test.property", input);
+        // When: range property is retrieved with inverted range
+        final int result = ConfigParser.getRangeProperty("test.property", 0, 15, 5);
+        // Then: should return default and report error
+        assertEquals(0, result, "should return default value when range is inverted");
+        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error for inverted range");
+        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid range"), "should report invalid range error");
+    }
+
+    @Test
+    @DisplayName("should return default and report error when range is inverted and property not set")
+    void shouldReturnDefaultAndReportErrorWhenRangeIsInvertedAndPropertyNotSet() {
+        // Given: property not set and inverted range
+        // When: range property is retrieved with inverted range
+        final int result = ConfigParser.getRangeProperty("nonexistent.property", 0, 15, 5);
+        // Then: should return default and report error
+        assertEquals(0, result, "should return default value when range is inverted and property not set");
+        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error for inverted range");
+        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid range"), "should report invalid range error");
+    }
+
+    @Test
+    @DisplayName("should accept range property when min equals max")
+    void shouldAcceptRangePropertyWhenMinEqualsMax() {
+        // Given: system property set to value equal to min and max
+        System.setProperty("test.property", "10");
+        // When: range property is retrieved with min equals max
+        final int result = ConfigParser.getRangeProperty("test.property", 0, 10, 10);
+        // Then: should return the value without errors
+        assertEquals(10, result, "should return value equal to min and max");
+        assertTrue(ConfigParser.isInitializationOK(), "should have no initialization errors when min equals max");
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = {"123456789", " 123456789", "123456789 ", " 123456789 "})
     @DisplayName("should parse long property correctly")
     void shouldParseLongPropertyCorrectly(final String value) {


### PR DESCRIPTION
## Context

`ConfigParser.getRangeProperty()` reads integer system properties and clamps them to a `[minValue, maxValue]` range. It is used internally by the configuration classes (`SessionConfig`, `ReporterConfig`, `WatcherConfig`, `SystemConfig`) to parse bounded numeric settings.

## Problem

When a caller accidentally inverts the range limits (`minValue > maxValue`), the method accepts the inverted range and produces confusing clamping behavior instead of reporting a clear configuration error.

Example with `minValue=15, maxValue=5`:

```java
System.setProperty("test.property", "10");
int result = ConfigParser.getRangeProperty("test.property", 0, 15, 5);
// result is 15 (the "minimum") ❌
```

The interval `[15, 5]` is logically invalid, but the error is silent and the returned value is misleading.

## Solution

Added an upfront validation in `ConfigParser.getRangeProperty()`. When `minValue > maxValue`, the method records an entry in `initializationErrors` and returns the `defaultValue`, keeping the error-handling style consistent with the rest of the class.

## API Changes

No public signature changes. Behavior changes only for the previously undefined case `minValue > maxValue`, which now fails safely with an error message instead of silently clamping.

Backward compatible for all valid inputs (`minValue <= maxValue`).

## Code Changes

- `src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java`
  - Added range validation to `getRangeProperty()`
  - Updated Javadoc
- `src/test/java/org/usefultoys/slf4j/utils/ConfigParserTest.java`
  - Added 3 tests covering inverted range with property set, inverted range with property missing, and `minValue == maxValue`

## Test Results

- `ConfigParserTest`: all tests pass
- Full suite: `.\mvnw.cmd test -P slf4j-2.0,with-logback` completed successfully

## Examples

```java
// Before: inverted range silently clamps
ConfigParser.getRangeProperty("test.property", 0, 15, 5);
// With test.property=10, returned 15 and no clear error

// After: inverted range reports an error and returns the default
ConfigParser.getRangeProperty("test.property", 0, 15, 5);
// Returns 0 and initializationErrors contains:
// "Invalid range for property 'test.property': minValue (15) is greater than maxValue (5). Using default value '0'."
```

---

Co-authored-by: GitHub Copilot using OpenCode Go / Kimi K2.7 Code