### PR TITLE
Fix handling of invalid values in UnitFormatter

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
@@ -26,6 +26,9 @@ import lombok.experimental.UtilityClass;
  *
  * <p>For example, it can convert large numbers into human-readable formats such as "1.2kB" or "3.4ms".
  *
+ * <p>Negative values, {@code NaN} and infinite values are not supported and are rendered as "?"
+ * followed by the base unit (e.g., "?B", "?ns", "?/s").
+ *
  * @author Daniel Felix Ferber
  * @author Co-authored-by: GitHub Copilot using OpenCode Go / Kimi K2.7 Code
  */
@@ -45,13 +48,20 @@ public final class UnitFormatter {
      * Formats a long integer value into a human-readable string with appropriate units.
      * This method is used internally by the public formatting methods.
      *
+     * <p>Negative values are not supported and are rendered as "?" followed by the base unit.
+     *
      * @param value The long integer value to format.
      * @param units An array of unit strings (e.g., "B", "kB", "MB").
      * @param factors An array of factors for unit conversion (e.g., 1000, 1000, 1000).
-     * @return A formatted string representing the value with units.
+     * @return A formatted string representing the value with units, or "?" followed by the base unit
+     *         when the value is negative.
      */
     @SuppressWarnings("AssignmentToMethodParameter")
     String longUnit(long value, @NonNull final String[] units, @NonNull final int[] factors) {
+        if (value < 0) {
+            return "?" + units[0];
+        }
+
         int index = 0;
         final int limit = factors[index] + factors[index] / 10;
         if (value < limit) {
@@ -78,15 +88,22 @@ public final class UnitFormatter {
      * Formats a double-precision floating-point value into a human-readable string with appropriate units.
      * This method is used internally by the public formatting methods.
      *
+     * <p>Negative values, {@code NaN} and infinite values are not supported and are rendered as "?"
+     * followed by the base unit.
+     *
      * @param value The double value to format.
      * @param units An array of unit strings (e.g., "/s", "k/s", "M/s").
      * @param factors An array of factors for unit conversion (e.g., 1000, 1000, 1000).
-     * @return A formatted string representing the value with units.
+     * @return A formatted string representing the value with units, or "?" followed by the base unit
+     *         when the value is negative, {@code NaN} or infinite.
      */
     @SuppressWarnings("AssignmentToMethodParameter")
     String doubleUnit(double value, @NonNull final String[] units, @NonNull final int[] factors) {
         if (value == 0.0) {
             return "0" + units[0];
+        }
+        if (value < 0.0 || Double.isNaN(value) || Double.isInfinite(value)) {
+            return "?" + units[0];
         }
 
         int index = 0;

--- a/src/test/java/org/usefultoys/slf4j/utils/UnitFormatterTest.java
+++ b/src/test/java/org/usefultoys/slf4j/utils/UnitFormatterTest.java
@@ -103,25 +103,25 @@ class UnitFormatterTest {
         assertEquals(expected, result, "should format value " + value + " as " + expected);
     }
 
-    static Stream<org.junit.jupiter.params.provider.Arguments> provideLongUnitNegativeTestCases() {
+    static Stream<org.junit.jupiter.params.provider.Arguments> provideLongUnitInvalidTestCases() {
         return Stream.of(
-            of(-1L, "-1A"),
-            of(-100L, "-100A"),
-            of(-999L, "-999A"),
-            of(-1000L, "-1000A"),
-            of(-1099L, "-1099A"),
-            of(Long.MIN_VALUE, "-9223372036854775808A")
+            of(-1L, "?A"),
+            of(-100L, "?A"),
+            of(-999L, "?A"),
+            of(-1000L, "?A"),
+            of(-1099L, "?A"),
+            of(Long.MIN_VALUE, "?A")
         );
     }
 
     @ParameterizedTest
-    @MethodSource("provideLongUnitNegativeTestCases")
-    @DisplayName("should format negative long values with first unit suffix")
-    void shouldFormatNegativeLongValuesWithFirstUnitSuffix(final long value, final String expected) {
+    @MethodSource("provideLongUnitInvalidTestCases")
+    @DisplayName("should format negative long values as invalid marker")
+    void shouldFormatNegativeLongValuesAsInvalidMarker(final long value, final String expected) {
         // Given: a negative long value
         // When: longUnit is called
         final String result = UnitFormatter.longUnit(value, UNITS, FACTORS);
-        // Then: should return value formatted with first unit, as negative values stay below the limit
+        // Then: should return "?" followed by the base unit, as negative values are not supported
         assertEquals(expected, result, "should format value " + value + " as " + expected);
     }
 
@@ -179,24 +179,27 @@ class UnitFormatterTest {
         assertEquals(expected, result, "should format value " + value + " as " + expected);
     }
 
-    static Stream<org.junit.jupiter.params.provider.Arguments> provideDoubleUnitNegativeTestCases() {
+    static Stream<org.junit.jupiter.params.provider.Arguments> provideDoubleUnitInvalidTestCases() {
         return Stream.of(
             of(-0.0, "0A"),
-            of(-1.0, "-1.0A"),
-            of(-999.0, "-999.0A"),
-            of(-1000.0, "-1000.0A"),
-            of(-1099.0, "-1099.0A")
+            of(-1.0, "?A"),
+            of(-999.0, "?A"),
+            of(-1000.0, "?A"),
+            of(-1099.0, "?A"),
+            of(Double.NaN, "?A"),
+            of(Double.POSITIVE_INFINITY, "?A"),
+            of(Double.NEGATIVE_INFINITY, "?A")
         );
     }
 
     @ParameterizedTest
-    @MethodSource("provideDoubleUnitNegativeTestCases")
-    @DisplayName("should format negative double values with first unit suffix")
-    void shouldFormatNegativeDoubleValuesWithFirstUnitSuffix(final double value, final String expected) {
-        // Given: a negative double value
+    @MethodSource("provideDoubleUnitInvalidTestCases")
+    @DisplayName("should format invalid double values as invalid marker")
+    void shouldFormatInvalidDoubleValuesAsInvalidMarker(final double value, final String expected) {
+        // Given: an invalid double value (negative, NaN or infinite)
         // When: doubleUnit is called
         final String result = UnitFormatter.doubleUnit(value, UNITS, FACTORS);
-        // Then: should return value formatted with first unit, as negative values stay below the limit
+        // Then: should return "?" followed by the base unit, as invalid values are not supported
         assertEquals(expected, result, "should format value " + value + " as " + expected);
     }
 


### PR DESCRIPTION
## Context

UnitFormatter formats numeric values into human-readable strings with units (bytes, nanoseconds, iterations, iterations per second). It is used by Meter, Watcher and Report components to render diagnostics.

## Problem

Special floating-point values and negative numbers were not handled explicitly:

```java
UnitFormatter.iterationsPerSecond(Double.NaN);                // "NaN/s" ❌
UnitFormatter.iterationsPerSecond(Double.POSITIVE_INFINITY);  // "InfinityG/s" ❌
UnitFormatter.nanoseconds(-5.0);                              // "-5.0ns" ❌
UnitFormatter.bytes(-1L);                                     // "-1B" ❌
```

These outputs are misleading because they suggest a legitimate measurement when the input was actually invalid or unsupported.

## Solution

Treat any unsupported value (negative long, negative double, NaN, positive infinity, negative infinity) as invalid and render it as `"?"` followed by the base unit. Zero keeps its existing `"0" + baseUnit` rendering.

Design choices:
- Used `"?"` because it is ASCII-only and safe for any log encoding (no Unicode assumptions).
- Used the base unit `units[0]` for invalid values, same as for zero.
- Did not distinguish between NaN and Infinity because both mean "no useful numeric value" for log consumers.

## API Changes

### Modified Behavior

- `UnitFormatter.bytes(long)`: negative values now return `"?B"` instead of `"-<value>B"`.
- `UnitFormatter.nanoseconds(long)`: negative values now return `"?ns"`.
- `UnitFormatter.iterations(long)`: negative values now return `"?"` (base unit).
- `UnitFormatter.nanoseconds(double)`: negative, NaN and infinite values now return `"?ns"`.
- `UnitFormatter.iterationsPerSecond(double)`: negative, NaN and infinite values now return `"?/s"`.

**Backward Compatibility**: Slightly backward incompatible for callers passing negative/NaN/Infinity values, but those inputs were never semantically valid. No public signatures changed.

## Code Changes

- `src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java`
  - `longUnit()`: early return `"?" + units[0]` for negative values.
  - `doubleUnit()`: early return `"?" + units[0]` for negative, NaN and infinite values.
  - Updated Javadoc for the class and both methods.
- `src/test/java/org/usefultoys/slf4j/utils/UnitFormatterTest.java`
  - Renamed and updated negative test cases to invalid test cases.
  - Added coverage for `Double.NaN`, `Double.POSITIVE_INFINITY`, `Double.NEGATIVE_INFINITY`.
  - Verified `-0.0` still renders as `"0A"`.

## Test Results

- `UnitFormatterTest`: 189 tests passed.
- Full suite with `with-logback`: 3125 tests passed (3050 core + 75 logback).

## Examples

```java
// Before
UnitFormatter.iterationsPerSecond(Double.NaN);                // "NaN/s"
UnitFormatter.iterationsPerSecond(Double.POSITIVE_INFINITY);  // "InfinityG/s"
UnitFormatter.bytes(-1L);                                     // "-1B"

// After
UnitFormatter.iterationsPerSecond(Double.NaN);                // "?/s"
UnitFormatter.iterationsPerSecond(Double.POSITIVE_INFINITY);  // "?/s"
UnitFormatter.bytes(-1L);                                     // "?B"
```

---

Co-Authored-By: OpenCode Go / Kimi K2.7 Code <noreply@opencode.ai>
