### PR TITLE
Fix silent overflow in ConfigParser.getMillisecondsProperty

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java
@@ -231,10 +231,14 @@ public class ConfigParser {
                 return defaultValue;
             }
 
-            return Long.parseLong(numberPart) * multiplier;
+            final long parsed = Long.parseLong(numberPart);
+            return Math.multiplyExact(parsed, (long) multiplier);
 
         } catch (final NumberFormatException e) {
             initializationErrors.add("Invalid time value for property '" + name + "': '" + rawValue + "'. Using default value '" + defaultValue + "'.");
+            return defaultValue;
+        } catch (final ArithmeticException e) {
+            initializationErrors.add("Time value overflow for property '" + name + "': '" + rawValue + "'. Using default value '" + defaultValue + "'.");
             return defaultValue;
         }
     }

--- a/src/test/java/org/usefultoys/slf4j/utils/ConfigParserTest.java
+++ b/src/test/java/org/usefultoys/slf4j/utils/ConfigParserTest.java
@@ -360,6 +360,39 @@ class ConfigParserTest {
         assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid time value"), "should report invalid time error");
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "9223372036854775807ms, 9223372036854775807",
+            "9223372036854775s, 9223372036854775000",
+            "153722867280912m, 9223372036854720000",
+            "2562047788015h, 9223372036854000000"
+    })
+    @DisplayName("should parse milliseconds property at boundary values")
+    void shouldParseMillisecondsPropertyAtBoundaryValues(final String input, final long expected) {
+        // Given: system property set with maximum representable time value
+        System.setProperty("test.property", input);
+        // When: milliseconds property is retrieved
+        final long result = ConfigParser.getMillisecondsProperty("test.property", 0L);
+        // Then: should return correct boundary value without errors
+        assertEquals(expected, result, "should return boundary value " + expected);
+        assertTrue(ConfigParser.isInitializationOK(), "should have no initialization errors");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"9223372036854776s", "153722867280913m", "2562047788016h", "-9223372036854775808s"})
+    @DisplayName("should report error when milliseconds property overflows")
+    void shouldReportErrorWhenMillisecondsPropertyOverflows(final String value) {
+        // Given: system property set to time value that overflows when converted to milliseconds
+        System.setProperty("test.property", value);
+        // When: milliseconds property is retrieved
+        final long result = ConfigParser.getMillisecondsProperty("test.property", 0L);
+        // Then: should return default and report overflow error
+        assertEquals(0L, result, "should return default value 0");
+        assertFalse(ConfigParser.isInitializationOK(), "should report initialization error");
+        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error");
+        assertTrue(ConfigParser.initializationErrors.get(0).contains("Time value overflow"), "should report overflow error");
+    }
+
     @Test
     @DisplayName("should return default value when milliseconds property is empty")
     void shouldReturnDefaultWhenMillisecondsPropertyEmpty() {


### PR DESCRIPTION
## Context

`ConfigParser.getMillisecondsProperty()` parses system properties that express durations with unit suffixes (`ms`, `s`, `m`/`min`, `h`). It is used by `SessionConfig`, `ReporterConfig`, `WatcherConfig` and `SystemConfig`.

## Problem

The method performed a plain `long` multiplication after parsing the numeric part:

```java
return Long.parseLong(numberPart) * multiplier;
```

When the parsed value multiplied by the suffix factor exceeded `Long.MAX_VALUE`, the result wrapped around silently to a negative value. No error was recorded in `initializationErrors`, so callers had no signal that the configuration was invalid:

```java
System.setProperty("test.property", "9223372036854776s");
long result = ConfigParser.getMillisecondsProperty("test.property", 0L);
// result was negative, isInitializationOK() returned true ❌
```

This could lead to negative timeouts or immediate scheduler triggers.

## Solution

Replace the unchecked multiplication with `Math.multiplyExact(long, long)` and catch `ArithmeticException`. On overflow, record a clear initialization error and fall back to the default value:

```java
final long parsed = Long.parseLong(numberPart);
return Math.multiplyExact(parsed, (long) multiplier);
```

`Math.multiplyExact` is available since Java 8, so the fix preserves Java 8+ compatibility.

## API Changes

No public signature changes. Behavior change: values that previously overflowed silently now return the default value and add an error to `ConfigParser.initializationErrors`. This is a bug fix and is backward compatible for all valid inputs.

## Code Changes

- `src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java`
  - Detect overflow in `getMillisecondsProperty()` using `Math.multiplyExact()`.
- `src/test/java/org/usefultoys/slf4j/utils/ConfigParserTest.java`
  - Add boundary-value tests for largest valid `ms`, `s`, `m` and `h` inputs.
  - Add regression tests for overflow with `s`, `m`, `h` and negative `Long.MIN_VALUE`.

## Test Results

- `ConfigParserTest`: 67 tests, 0 failures
- Full core suite: 3055 tests, 0 failures
- Full suite with Logback: 3130 tests (3055 core + 75 logback), 0 failures

## Examples

Before:

```java
System.setProperty("test.property", "9223372036854776s");
ConfigParser.getMillisecondsProperty("test.property", 0L);
// returned a negative long, no initialization error
```

After:

```java
System.setProperty("test.property", "9223372036854776s");
long value = ConfigParser.getMillisecondsProperty("test.property", 0L);
// value == 0L
// ConfigParser.initializationErrors contains:
// "Time value overflow for property 'test.property': '9223372036854776s'. Using default value '0'."
```

---

Co-Authored-By: OpenCode Go / Kimi K2.7 Code <noreply@opencode.ai>
