### PR TITLE
Encapsulate ConfigParser.initializationErrors as private with bounded accessor

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/ConfigParser.java
@@ -30,7 +30,7 @@ import java.util.List;
  * This class is not meant to be instantiated.
  * <p>
  * <strong>Security note regarding CWE-209 (Information Exposure Through Error Message):</strong>
- * Error messages recorded in {@link #initializationErrors} include the raw property value to aid debugging.
+ * Error messages recorded in {@link #getInitializationErrors()} include the raw property value to aid debugging.
  * This is accepted by design and is not considered a CWE-209 vulnerability. This class is used solely to
  * obtain configuration defined in {@link org.usefultoys.slf4j.SessionConfig},
  * {@link org.usefultoys.slf4j.report.ReporterConfig}, {@link org.usefultoys.slf4j.watcher.WatcherConfig},
@@ -44,10 +44,20 @@ import java.util.List;
 public class ConfigParser {
 
     /**
-     * A list of errors that occurred during property parsing. Applications can inspect this list
-     * after initialization to check for configuration issues.
+     * Maximum number of error messages to retain. Once reached, the oldest error is discarded
+     * when a new error is added to prevent unbounded memory growth.
      */
-    public final List<String> initializationErrors = Collections.synchronizedList(new ArrayList<>());
+    private static final int MAX_ERRORS = 100;
+
+    /**
+     * A list of errors that occurred during property parsing. This list is private and only
+     * modifiable through the methods of this class. Applications can inspect the errors through
+     * {@link #getInitializationErrors()}, which returns an unmodifiable view.
+     * <p>
+     * The list is bounded at {@value #MAX_ERRORS} entries; once full, the oldest entry is
+     * evicted to prevent unbounded memory growth.
+     */
+    private final List<String> initializationErrors = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Checks if any errors occurred during property parsing.
@@ -59,10 +69,33 @@ public class ConfigParser {
     }
 
     /**
+     * Returns an unmodifiable view of the errors that occurred during property parsing.
+     * Applications can inspect this list after initialization to check for configuration issues.
+     *
+     * @return an unmodifiable list of error messages; never {@code null}
+     */
+    public List<String> getInitializationErrors() {
+        return Collections.unmodifiableList(initializationErrors);
+    }
+
+    /**
      * Clears all recorded initialization errors. This is useful for testing or re-initialization.
      */
     public void clearInitializationErrors() {
         initializationErrors.clear();
+    }
+
+    /**
+     * Records an initialization error message, evicting the oldest entry if the list has reached
+     * {@value #MAX_ERRORS} entries.
+     *
+     * @param message the error message to record
+     */
+    private void addInitializationError(final String message) {
+        initializationErrors.add(message);
+        if (initializationErrors.size() > MAX_ERRORS) {
+            initializationErrors.remove(0);
+        }
     }
 
     /**
@@ -98,7 +131,7 @@ public class ConfigParser {
         if (trimmedValue.equalsIgnoreCase("false")) {
             return false;
         }
-        initializationErrors.add("Invalid boolean value for property '" + name + "': '" + value + "'. Using default value '" + defaultValue + "'.");
+        addInitializationError("Invalid boolean value for property '" + name + "': '" + value + "'. Using default value '" + defaultValue + "'.");
         return defaultValue;
     }
 
@@ -118,7 +151,7 @@ public class ConfigParser {
         try {
             return Integer.parseInt(value.trim());
         } catch (final NumberFormatException e) {
-            initializationErrors.add("Invalid integer value for property '" + name + "': '" + value + "'. Using default value '" + defaultValue + "'.");
+            addInitializationError("Invalid integer value for property '" + name + "': '" + value + "'. Using default value '" + defaultValue + "'.");
             return defaultValue;
         }
     }
@@ -143,7 +176,7 @@ public class ConfigParser {
                                 final int minValue, final int maxValue) {
         /* Reject invalid ranges to avoid silently confusing clamping behavior */
         if (minValue > maxValue) {
-            initializationErrors.add("Invalid range for property '" + name + "': minValue (" + minValue + ") is greater than maxValue (" + maxValue + "). Using default value '" + defaultValue + "'.");
+            addInitializationError("Invalid range for property '" + name + "': minValue (" + minValue + ") is greater than maxValue (" + maxValue + "). Using default value '" + defaultValue + "'.");
             return defaultValue;
         }
         final String value = System.getProperty(name);
@@ -153,16 +186,16 @@ public class ConfigParser {
         try {
             final int intValue = Integer.parseInt(value.trim());
             if (intValue < minValue) {
-                initializationErrors.add("Value for property '" + name + "' is below minimum " + minValue + ": '" + value + "'. Using minimum value.");
+                addInitializationError("Value for property '" + name + "' is below minimum " + minValue + ": '" + value + "'. Using minimum value.");
                 return minValue;
             }
             if (intValue > maxValue) {
-                initializationErrors.add("Value for property '" + name + "' is above maximum " + maxValue + ": '" + value + "'. Using maximum value.");
+                addInitializationError("Value for property '" + name + "' is above maximum " + maxValue + ": '" + value + "'. Using maximum value.");
                 return maxValue;
             }
             return intValue;
         } catch (final NumberFormatException e) {
-            initializationErrors.add("Invalid integer value for property '" + name + "': '" + value + "'. Using default value '" + defaultValue + "'.");
+            addInitializationError("Invalid integer value for property '" + name + "': '" + value + "'. Using default value '" + defaultValue + "'.");
             return defaultValue;
         }
     }
@@ -183,7 +216,7 @@ public class ConfigParser {
         try {
             return Long.parseLong(value.trim());
         } catch (final NumberFormatException e) {
-            initializationErrors.add("Invalid long value for property '" + name + "': '" + value + "'. Using default value '" + defaultValue + "'.");
+            addInitializationError("Invalid long value for property '" + name + "': '" + value + "'. Using default value '" + defaultValue + "'.");
             return defaultValue;
         }
     }
@@ -227,7 +260,7 @@ public class ConfigParser {
 
             final String numberPart = value.substring(0, value.length() - suffixLength).trim();
             if (numberPart.isEmpty()) {
-                initializationErrors.add("Invalid time value for property '" + name + "': '" + rawValue + "'. Using default value '" + defaultValue + "'.");
+                addInitializationError("Invalid time value for property '" + name + "': '" + rawValue + "'. Using default value '" + defaultValue + "'.");
                 return defaultValue;
             }
 
@@ -235,10 +268,10 @@ public class ConfigParser {
             return Math.multiplyExact(parsed, (long) multiplier);
 
         } catch (final NumberFormatException e) {
-            initializationErrors.add("Invalid time value for property '" + name + "': '" + rawValue + "'. Using default value '" + defaultValue + "'.");
+            addInitializationError("Invalid time value for property '" + name + "': '" + rawValue + "'. Using default value '" + defaultValue + "'.");
             return defaultValue;
         } catch (final ArithmeticException e) {
-            initializationErrors.add("Time value overflow for property '" + name + "': '" + rawValue + "'. Using default value '" + defaultValue + "'.");
+            addInitializationError("Time value overflow for property '" + name + "': '" + rawValue + "'. Using default value '" + defaultValue + "'.");
             return defaultValue;
         }
     }

--- a/src/test/java/org/usefultoys/slf4j/SystemConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/SystemConfigTest.java
@@ -110,8 +110,8 @@ class SystemConfigTest {
         // Then: should use default value and report error
         assertFalse(SystemConfig.useClassLoadingManagedBean, "useClassLoadingManagedBean should fall back to default for invalid format"); // Default is false
         assertFalse(ConfigParser.isInitializationOK());
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_CLASS_LOADING_MANAGED_BEAN));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_CLASS_LOADING_MANAGED_BEAN));
     }
 
     @Test
@@ -148,8 +148,8 @@ class SystemConfigTest {
         // Then: should use default value and report error
         assertFalse(SystemConfig.useMemoryManagedBean, "useMemoryManagedBean should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK());
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_MEMORY_MANAGED_BEAN));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_MEMORY_MANAGED_BEAN));
     }
 
     @Test
@@ -186,8 +186,8 @@ class SystemConfigTest {
         // Then: should use default value and report error
         assertFalse(SystemConfig.useCompilationManagedBean, "useCompilationManagedBean should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK());
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_COMPILATION_MANAGED_BEAN));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_COMPILATION_MANAGED_BEAN));
     }
 
     @Test
@@ -224,8 +224,8 @@ class SystemConfigTest {
         // Then: should use default value and report error
         assertFalse(SystemConfig.useGarbageCollectionManagedBean, "useGarbageCollectionManagedBean should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK());
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_GARBAGE_COLLECTION_MANAGED_BEAN));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_GARBAGE_COLLECTION_MANAGED_BEAN));
     }
 
     @Test
@@ -262,7 +262,7 @@ class SystemConfigTest {
         // Then: should use default value and report error
         assertFalse(SystemConfig.usePlatformManagedBean, "usePlatformManagedBean should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK());
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_PLATFORM_MANAGED_BEAN));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + SystemConfig.PROP_USE_PLATFORM_MANAGED_BEAN));
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
@@ -111,8 +111,8 @@ class MeterConfigTest {
         MeterConfig.init();
         assertEquals(2000L, MeterConfig.progressPeriodMilliseconds, "progressPeriodMilliseconds should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid progressPeriodMilliseconds format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid time value for property '" + MeterConfig.PROP_PROGRESS_PERIOD));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid time value for property '" + MeterConfig.PROP_PROGRESS_PERIOD));
     }
 
     /**
@@ -137,8 +137,8 @@ class MeterConfigTest {
         MeterConfig.init();
         assertFalse(MeterConfig.printCategory, "printCategory should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid printCategory format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_CATEGORY));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_CATEGORY));
     }
 
     /**
@@ -163,8 +163,8 @@ class MeterConfigTest {
         MeterConfig.init();
         assertTrue(MeterConfig.printStatus, "printStatus should fall back to default for invalid format"); // Default is true
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid printStatus format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_STATUS));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_STATUS));
     }
 
     /**
@@ -189,8 +189,8 @@ class MeterConfigTest {
         MeterConfig.init();
         assertFalse(MeterConfig.printPosition, "printPosition should fall back to default for invalid format"); // Default is false
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid printPosition format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_POSITION));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_POSITION));
     }
 
     /**
@@ -215,8 +215,8 @@ class MeterConfigTest {
         MeterConfig.init();
         assertFalse(MeterConfig.printLoad, "printLoad should fall back to default for invalid format"); // Default is false
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid printLoad format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_LOAD));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_LOAD));
     }
 
     /**
@@ -241,8 +241,8 @@ class MeterConfigTest {
         MeterConfig.init();
         assertFalse(MeterConfig.printMemory, "printMemory should fall back to default for invalid format"); // Default is false
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid printMemory format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_MEMORY));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + MeterConfig.PROP_PRINT_MEMORY));
     }
 
     /**

--- a/src/test/java/org/usefultoys/slf4j/report/ReportJavaxServletTest.java
+++ b/src/test/java/org/usefultoys/slf4j/report/ReportJavaxServletTest.java
@@ -283,7 +283,7 @@ class ReportJavaxServletTest {
         verify(response).setStatus(HttpServletResponse.SC_OK);
         assertTrue(responseWriter.toString().contains("Report logged for: networkinterface"));
         // Cannot easily assert specific content without mocking NetworkInterface
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test

--- a/src/test/java/org/usefultoys/slf4j/report/ReportServletTest.java
+++ b/src/test/java/org/usefultoys/slf4j/report/ReportServletTest.java
@@ -293,7 +293,7 @@ class ReportServletTest {
         verify(response).setStatus(HttpServletResponse.SC_OK);
         assertTrue(responseWriter.toString().contains("Report logged for: networkinterface"));
         // Cannot easily assert specific content without mocking NetworkInterface
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test

--- a/src/test/java/org/usefultoys/slf4j/report/ReportSystemEnvironmentTest.java
+++ b/src/test/java/org/usefultoys/slf4j/report/ReportSystemEnvironmentTest.java
@@ -86,7 +86,7 @@ class ReportSystemEnvironmentTest {
                 "TEST_PASSWORD: ********",
                 "TEST_SECRET: ********",
                 "TEST_NORMAL: normalvalue");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -107,7 +107,7 @@ class ReportSystemEnvironmentTest {
         assertEvent(logger, 0, MockLoggerEvent.Level.INFO,
                 "TEST_CUSTOM_KEY: ********",
                 "TEST_NORMAL: normalvalue");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -128,7 +128,7 @@ class ReportSystemEnvironmentTest {
         assertEvent(logger, 0, MockLoggerEvent.Level.INFO,
                 "TEST_PASSWORD: mysecretpassword",
                 "TEST_SECRET: anothersecret");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -149,6 +149,6 @@ class ReportSystemEnvironmentTest {
         assertEvent(logger, 0, MockLoggerEvent.Level.INFO,
                 "TEST_PASSWORD: mysecretpassword",
                 "TEST_SECRET: anothersecret");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/report/ReportSystemPropertiesTest.java
+++ b/src/test/java/org/usefultoys/slf4j/report/ReportSystemPropertiesTest.java
@@ -76,7 +76,7 @@ class ReportSystemPropertiesTest {
                 "test.password: ********",
                 "test.secret: ********",
                 "test.normal: normalvalue");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -98,7 +98,7 @@ class ReportSystemPropertiesTest {
         assertEvent(logger, 0, MockLoggerEvent.Level.INFO,
                 "test.custom.key: ********",
                 "test.normal: normalvalue");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -120,7 +120,7 @@ class ReportSystemPropertiesTest {
         assertEvent(logger, 0, MockLoggerEvent.Level.INFO,
                 "test.password: mysecretpassword",
                 "test.secret: anothersecret");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -142,6 +142,6 @@ class ReportSystemPropertiesTest {
         assertEvent(logger, 0, MockLoggerEvent.Level.INFO,
                 "test.password: mysecretpassword",
                 "test.secret: anothersecret");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/report/ReporterConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/report/ReporterConfigTest.java
@@ -139,8 +139,8 @@ class ReporterConfigTest {
         ReporterConfig.init();
         assertTrue(ReporterConfig.reportVM, "reportVM should fall back to default (true) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_VM), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_VM), "Error message should mention the invalid property");
     }
 
     @Test
@@ -165,8 +165,8 @@ class ReporterConfigTest {
         // Then: reportFileSystem should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportFileSystem, "reportFileSystem should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_FILE_SYSTEM), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_FILE_SYSTEM), "Error message should mention the invalid property");
     }
 
     @Test
@@ -191,8 +191,8 @@ class ReporterConfigTest {
         // Then: reportMemory should fall back to default (true), error should be reported
         assertTrue(ReporterConfig.reportMemory, "reportMemory should fall back to default (true) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_MEMORY), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_MEMORY), "Error message should mention the invalid property");
     }
 
     @Test
@@ -217,8 +217,8 @@ class ReporterConfigTest {
         // Then: reportUser should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportUser, "reportUser should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_USER), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_USER), "Error message should mention the invalid property");
     }
 
     @Test
@@ -243,8 +243,8 @@ class ReporterConfigTest {
         // Then: reportProperties should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportProperties, "reportProperties should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_PROPERTIES), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_PROPERTIES), "Error message should mention the invalid property");
     }
 
     @Test
@@ -269,8 +269,8 @@ class ReporterConfigTest {
         // Then: reportEnvironment should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportEnvironment, "reportEnvironment should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_ENVIRONMENT), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_ENVIRONMENT), "Error message should mention the invalid property");
     }
 
     @Test
@@ -295,8 +295,8 @@ class ReporterConfigTest {
         // Then: reportPhysicalSystem should fall back to default (true), error should be reported
         assertTrue(ReporterConfig.reportPhysicalSystem, "reportPhysicalSystem should fall back to default (true) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_PHYSICAL_SYSTEM), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_PHYSICAL_SYSTEM), "Error message should mention the invalid property");
     }
 
     @Test
@@ -321,8 +321,8 @@ class ReporterConfigTest {
         // Then: reportOperatingSystem should fall back to default (true), error should be reported
         assertTrue(ReporterConfig.reportOperatingSystem, "reportOperatingSystem should fall back to default (true) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_OPERATING_SYSTEM), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_OPERATING_SYSTEM), "Error message should mention the invalid property");
     }
 
     @Test
@@ -347,8 +347,8 @@ class ReporterConfigTest {
         // Then: reportCalendar should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportCalendar, "reportCalendar should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_CALENDAR), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_CALENDAR), "Error message should mention the invalid property");
     }
 
     @Test
@@ -373,8 +373,8 @@ class ReporterConfigTest {
         // Then: reportLocale should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportLocale, "reportLocale should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_LOCALE), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_LOCALE), "Error message should mention the invalid property");
     }
 
     @Test
@@ -399,8 +399,8 @@ class ReporterConfigTest {
         // Then: reportCharset should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportCharset, "reportCharset should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_CHARSET), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_CHARSET), "Error message should mention the invalid property");
     }
 
     @Test
@@ -425,8 +425,8 @@ class ReporterConfigTest {
         // Then: reportNetworkInterface should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportNetworkInterface, "reportNetworkInterface should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_NETWORK_INTERFACE), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_NETWORK_INTERFACE), "Error message should mention the invalid property");
     }
 
     @Test
@@ -451,8 +451,8 @@ class ReporterConfigTest {
         // Then: reportSSLContext should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportSSLContext, "reportSSLContext should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_SSL_CONTEXT), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_SSL_CONTEXT), "Error message should mention the invalid property");
     }
 
     @Test
@@ -477,8 +477,8 @@ class ReporterConfigTest {
         // Then: reportDefaultTrustKeyStore should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportDefaultTrustKeyStore, "reportDefaultTrustKeyStore should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_DEFAULT_TRUST_KEYSTORE), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_DEFAULT_TRUST_KEYSTORE), "Error message should mention the invalid property");
     }
 
     @Test
@@ -503,8 +503,8 @@ class ReporterConfigTest {
         // Then: reportJvmArguments should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportJvmArguments, "reportJvmArguments should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_JVM_ARGUMENTS), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_JVM_ARGUMENTS), "Error message should mention the invalid property");
     }
 
     @Test
@@ -529,8 +529,8 @@ class ReporterConfigTest {
         // Then: reportClasspath should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportClasspath, "reportClasspath should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_CLASSPATH), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_CLASSPATH), "Error message should mention the invalid property");
     }
 
     @Test
@@ -555,8 +555,8 @@ class ReporterConfigTest {
         // Then: reportGarbageCollector should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportGarbageCollector, "reportGarbageCollector should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_GARBAGE_COLLECTOR), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_GARBAGE_COLLECTOR), "Error message should mention the invalid property");
     }
 
     @Test
@@ -581,8 +581,8 @@ class ReporterConfigTest {
         // Then: reportSecurityProviders should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportSecurityProviders, "reportSecurityProviders should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_SECURITY_PROVIDERS), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_SECURITY_PROVIDERS), "Error message should mention the invalid property");
     }
 
     @Test
@@ -607,8 +607,8 @@ class ReporterConfigTest {
         // Then: reportContainerInfo should fall back to default (false), error should be reported
         assertFalse(ReporterConfig.reportContainerInfo, "reportContainerInfo should fall back to default (false) when value is invalid");
         assertFalse(ConfigParser.isInitializationOK(), "Configuration error should be reported for invalid value");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "Exactly one error should be reported");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_CONTAINER_INFO), "Error message should mention the invalid property");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "Exactly one error should be reported");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value for property '" + ReporterConfig.PROP_CONTAINER_INFO), "Error message should mention the invalid property");
     }
 
     @Test

--- a/src/test/java/org/usefultoys/slf4j/report/ReporterTest.java
+++ b/src/test/java/org/usefultoys/slf4j/report/ReporterTest.java
@@ -123,7 +123,7 @@ class ReporterTest {
         // So, 20 - 2 = 18 reports.
         assertEquals(18, executionCount.get(), "All enabled reports should be executed");
         AssertLogger.assertHasEvent(logger, "Physical system");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -150,7 +150,7 @@ class ReporterTest {
         assertEquals(6, executionCount.get(), "Only 6 reports should be executed");
         AssertLogger.assertHasEvent(logger, "Java Virtual Machine");
         AssertLogger.assertHasEvent(logger, "System Properties");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -192,7 +192,7 @@ class ReporterTest {
         assertEquals(0, executionCount.get(), "No reports should be executed");
         AssertLogger.assertNoEvent(logger, "Java Virtual Machine");
         AssertLogger.assertNoEvent(logger, "Physical system");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -213,7 +213,7 @@ class ReporterTest {
 
         // Then: reports should be logged to the test logger
         AssertLogger.assertHasEvent(logger, "Physical system");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -242,7 +242,7 @@ class ReporterTest {
 
         // Then: error message should be logged
         AssertLogger.assertHasEvent(logger, "Cannot report network interfaces");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -334,7 +334,7 @@ class ReporterTest {
         AssertLogger.assertHasEvent(logger, "Network Interface lo:");
         AssertLogger.assertHasEvent(logger, "NET address (IPV4): 192.168.1.10");
         AssertLogger.assertHasEvent(logger, "NET address (IPV4): 127.0.0.1");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -391,7 +391,7 @@ class ReporterTest {
         assertEquals(5, executionCount.get(), "Enabled reports should still be executed");
         AssertLogger.assertNoEvent(logger, "Java Virtual Machine");
         AssertLogger.assertNoEvent(logger, "System Properties");
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 
     @Test
@@ -410,6 +410,6 @@ class ReporterTest {
 
         // Then: should execute without error and log at least the network interface header
         // Note: The actual network interfaces depend on the machine, but the code path is exercised
-        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "No ConfigParser errors expected: " + ConfigParser.getInitializationErrors());
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/utils/ConfigParserTest.java
+++ b/src/test/java/org/usefultoys/slf4j/utils/ConfigParserTest.java
@@ -105,8 +105,8 @@ class ConfigParserTest {
         // Then: should return default and report error
         assertTrue(result, "should return default value true");
         assertFalse(ConfigParser.isInitializationOK(), "should report initialization error");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid boolean value"), "should report invalid boolean error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid boolean value"), "should report invalid boolean error");
     }
 
     @Test
@@ -143,8 +143,8 @@ class ConfigParserTest {
         // Then: should return default and report error
         assertEquals(0, result, "should return default value 0");
         assertFalse(ConfigParser.isInitializationOK(), "should report initialization error");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid integer value"), "should report invalid integer error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid integer value"), "should report invalid integer error");
     }
 
     @Test
@@ -202,8 +202,8 @@ class ConfigParserTest {
         final int result = ConfigParser.getRangeProperty("test.property", 0, 5, 15);
         // Then: should clamp to the minimum and report an error
         assertEquals(expected, result, "should clamp value " + input + " to minimum " + expected);
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error for value " + input);
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("below minimum"), "should report below-minimum error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error for value " + input);
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("below minimum"), "should report below-minimum error");
     }
 
     @ParameterizedTest
@@ -219,8 +219,8 @@ class ConfigParserTest {
         final int result = ConfigParser.getRangeProperty("test.property", 0, 5, 15);
         // Then: should clamp to the maximum and report an error
         assertEquals(expected, result, "should clamp value " + input + " to maximum " + expected);
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error for value " + input);
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("above maximum"), "should report above-maximum error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error for value " + input);
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("above maximum"), "should report above-maximum error");
     }
 
     @Test
@@ -232,8 +232,8 @@ class ConfigParserTest {
         final int result = ConfigParser.getRangeProperty("test.property", 0, 5, 15);
         // Then: should return default and report error
         assertEquals(0, result, "should return default value 0");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid integer value"), "should report invalid integer error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid integer value"), "should report invalid integer error");
     }
 
     @Test
@@ -257,8 +257,8 @@ class ConfigParserTest {
         final int result = ConfigParser.getRangeProperty("test.property", 0, 15, 5);
         // Then: should return default and report error
         assertEquals(0, result, "should return default value when range is inverted");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error for inverted range");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid range"), "should report invalid range error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error for inverted range");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid range"), "should report invalid range error");
     }
 
     @Test
@@ -269,8 +269,8 @@ class ConfigParserTest {
         final int result = ConfigParser.getRangeProperty("nonexistent.property", 0, 15, 5);
         // Then: should return default and report error
         assertEquals(0, result, "should return default value when range is inverted and property not set");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error for inverted range");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid range"), "should report invalid range error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error for inverted range");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid range"), "should report invalid range error");
     }
 
     @Test
@@ -307,8 +307,8 @@ class ConfigParserTest {
         final long result = ConfigParser.getProperty("test.property", 0L);
         // Then: should return default and report error
         assertEquals(0L, result, "should return default value 0");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid long value"), "should report invalid long error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid long value"), "should report invalid long error");
     }
 
     @Test
@@ -356,8 +356,8 @@ class ConfigParserTest {
         final long result = ConfigParser.getMillisecondsProperty("test.property", 0L);
         // Then: should return default and report error
         assertEquals(0L, result, "should return default value 0");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Invalid time value"), "should report invalid time error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Invalid time value"), "should report invalid time error");
     }
 
     @ParameterizedTest
@@ -389,8 +389,8 @@ class ConfigParserTest {
         // Then: should return default and report overflow error
         assertEquals(0L, result, "should return default value 0");
         assertFalse(ConfigParser.isInitializationOK(), "should report initialization error");
-        assertEquals(1, ConfigParser.initializationErrors.size(), "should have one error");
-        assertTrue(ConfigParser.initializationErrors.get(0).contains("Time value overflow"), "should report overflow error");
+        assertEquals(1, ConfigParser.getInitializationErrors().size(), "should have one error");
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains("Time value overflow"), "should report overflow error");
     }
 
     @Test
@@ -414,5 +414,21 @@ class ConfigParserTest {
         // Then: should return default value
         assertEquals(0L, result, "should return default value 0");
         assertTrue(ConfigParser.isInitializationOK(), "should have no initialization errors");
+    }
+
+    @Test
+    @DisplayName("should evict oldest error when list exceeds maximum size")
+    void shouldEvictOldestErrorWhenListExceedsMaxSize() {
+        final int totalErrors = 150;
+        final int maxErrors = 100;
+        for (int i = 0; i < totalErrors; i++) {
+            System.setProperty("test.bounded." + i, "not_an_int");
+            ConfigParser.getProperty("test.bounded." + i, 42);
+            System.clearProperty("test.bounded." + i);
+        }
+        assertEquals(maxErrors, ConfigParser.getInitializationErrors().size(), "should be capped at max errors");
+        assertFalse(ConfigParser.getInitializationErrors().get(0).contains("test.bounded.0"),
+                "oldest errors should be evicted");
+        assertFalse(ConfigParser.isInitializationOK(), "should report initialization errors");
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/watcher/WatcherConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/watcher/WatcherConfigTest.java
@@ -110,8 +110,8 @@ class WatcherConfigTest {
         // Then: delayMilliseconds should use default and report error
         assertEquals(60000L, WatcherConfig.delayMilliseconds, "delayMilliseconds should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid delayMilliseconds format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains(String.format("Invalid time value for property '%s", WatcherConfig.PROP_DELAY)));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains(String.format("Invalid time value for property '%s", WatcherConfig.PROP_DELAY)));
     }
 
     @Test
@@ -140,8 +140,8 @@ class WatcherConfigTest {
         // Then: periodMilliseconds should use default and report error
         assertEquals(600000L, WatcherConfig.periodMilliseconds, "periodMilliseconds should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid periodMilliseconds format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains(String.format("Invalid time value for property '%s", WatcherConfig.PROP_PERIOD)));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains(String.format("Invalid time value for property '%s", WatcherConfig.PROP_PERIOD)));
     }
 
     @Test
@@ -198,8 +198,8 @@ class WatcherConfigTest {
         // Then: dataEnabled should use default and report error
         assertFalse(WatcherConfig.dataEnabled, "dataEnabled should fall back to default for invalid format");
         assertFalse(ConfigParser.isInitializationOK(), "An error should be reported for invalid dataEnabled format");
-        assertEquals(1, ConfigParser.initializationErrors.size());
-        assertTrue(ConfigParser.initializationErrors.get(0).contains(String.format("Invalid boolean value for property '%s", WatcherConfig.PROP_DATA_ENABLED)));
+        assertEquals(1, ConfigParser.getInitializationErrors().size());
+        assertTrue(ConfigParser.getInitializationErrors().get(0).contains(String.format("Invalid boolean value for property '%s", WatcherConfig.PROP_DATA_ENABLED)));
     }
 
     @Test

--- a/src/test/java/org/usefultoys/slf4j/watcher/WatcherTest.java
+++ b/src/test/java/org/usefultoys/slf4j/watcher/WatcherTest.java
@@ -116,7 +116,7 @@ class WatcherTest {
         System.setProperty(WatcherConfig.PROP_DATA_SUFFIX, scenario.dataSuffix);
         System.setProperty(WatcherConfig.PROP_DATA_ENABLED, String.valueOf(scenario.dataEnabled));
         WatcherConfig.init();
-        assertTrue(ConfigParser.isInitializationOK(), "ConfigParser should have no errors for scenario: " + scenario.testName + " - " + ConfigParser.initializationErrors);
+        assertTrue(ConfigParser.isInitializationOK(), "ConfigParser should have no errors for scenario: " + scenario.testName + " - " + ConfigParser.getInitializationErrors());
 
         // 2. Get the mock loggers that the Watcher will use
         final String messageLoggerName = scenario.messagePrefix + TEST_WATCHER_NAME + scenario.messageSuffix;


### PR DESCRIPTION
﻿## Context

`ConfigParser` accumulates property-parsing errors in a global static mutable list that any JVM code can read or write directly. The list has no bound, so repeated reconfiguration can leak memory indefinitely.

## Problem

`initializationErrors` is declared `public final` in a Lombok `@UtilityClass`, making it `public static final` -- global mutable state accessible by any code in the JVM:

```java
// Any code anywhere in the JVM can do:
ConfigParser.initializationErrors.add("fake error");   // inject false errors
ConfigParser.initializationErrors.clear();              // destroy legitimate errors
ConfigParser.initializationErrors.remove(0);            // tamper with the list
```

Additionally, the list grows without bound -- repeated config parsing (dynamic reconfiguration) can leak memory over time.

## Solution

**Make the list private** and expose it only through a controlled accessor that returns an unmodifiable view:

```java
// Before:
public final List<String> initializationErrors = ...;

// After:
private final List<String> initializationErrors = ...;
public List<String> getInitializationErrors() { return Collections.unmodifiableList(...); }
```

**Add a hard size limit** (`MAX_ERRORS = 100`) via a private helper method that evicts the oldest entry when the list exceeds the bound. A config module in practice has at most a few dozen properties, so 100 entries is ample headroom while guaranteeing memory doesn't grow indefinitely.

## API Changes

- **ConfigParser.initializationErrors**: `public` -> `private` (breaking: external code cannot access the field directly anymore)
- **New**: `ConfigParser.getInitializationErrors()` returns `List<String>` (unmodifiable view)

**Backward Compatibility**: All existing callers that accessed `ConfigParser.initializationErrors` must switch to `ConfigParser.getInitializationErrors()`. The set of public methods on the class is one bigger and one smaller -- callers referencing the old field will get a compilation error and must update to the new method. In `slf4j-toys` itself, all 100+ internal call sites have been migrated.

## Code Changes

**Production** (1 file):
- `ConfigParser.java`: field privatized, new accessor method, new bounded-add helper with `MAX_ERRORS`

**Tests** (11 files, +1 test):
- All test files updated from `ConfigParser.initializationErrors` to `ConfigParser.getInitializationErrors()`
- New `ConfigParserTest.shouldEvictOldestErrorWhenListExceedsMaxSize` -- adds 150 errors and verifies the list is capped at 100, with oldest entries evicted

## Test Results

All 3134 tests pass (3059 core + 75 logback), no regressions:

```
Tests run: 3059, Failures: 0, Errors: 0, Skipped: 0  (core)
Tests run: 75,   Failures: 0, Errors: 0, Skipped: 0  (logback)
BUILD SUCCESS
```

---

Co-Authored-By: OpenCode Go / DeepSeek V4 Pro <noreply@opencode.ai>
