### PR TITLE
Replace WatcherSingleton push with instance-based WatcherExecutorController and WatcherTimerController

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,49 +18,9 @@ The library introduces:
 
 ## Watcher
 
-The `Watcher` component periodically reports the state of the JVM and the underlying platform. It is designed for **instance-based lifecycle management**: each push mechanism (`ScheduledExecutorService` or `Timer`) is wrapped by its own controller, which owns a dedicated `Watcher` instance.
+The `Watcher` component periodically reports the state of the JVM and the underlying platform. For simple standalone applications, use the built-in `WatcherExecutorController` or `WatcherTimerController`; for enterprise applications, integrate the `Watcher` `Runnable` with your framework's scheduler (e.g., Spring `@Scheduled`, EJB `@Schedule`).
 
-### Push controllers
-
-Use `WatcherExecutorController` or `WatcherTimerController` to schedule automatic reports. Both read `WatcherConfig` defaults (`name`, `delay`, `period`) when created, and expose `create()` shortcuts plus a fluent `Builder` for customization.
-
-```java
-// Defaults from WatcherConfig (name="watcher", delay=1m, period=10m)
-try (WatcherExecutorController controller = WatcherExecutorController.create()) {
-    controller.start();
-    // runs until the application shuts down or stop()/close() is called
-}
-
-// Custom name and schedule
-WatcherTimerController timer = WatcherTimerController.create("myapp", 30_000, 60_000);
-timer.start();
-
-// Full builder flexibility
-WatcherExecutorController controller = WatcherExecutorController.builder()
-    .name("ops")
-    .delayMilliseconds(5_000)
-    .periodMilliseconds(30_000)
-    .build();
-controller.start();
-```
-
-The controllers use **daemon threads** named after the watcher, so they do not block JVM shutdown.
-
-### Configuration
-
-All defaults are read from `WatcherConfig`, which is populated from system properties at class-load time:
-
-| Property | Default | Description |
-|---|---|---|
-| `slf4jtoys.watcher.name` | `watcher` | Logger/thread name used by the default watcher. |
-| `slf4jtoys.watcher.delay` | `60000` | Initial delay before the first report. |
-| `slf4jtoys.watcher.period` | `600000` | Interval between reports. |
-
-You may also set `WatcherConfig` fields programmatically before creating a controller; values are captured at build time.
-
-### Legacy `WatcherSingleton`
-
-`WatcherSingleton` is **deprecated** and now only provides the default `Watcher` instance for the servlet pull path. Its push methods (`startDefaultWatcherExecutor`, `startDefaultWatcherTimer`) have been removed; migrate to `WatcherExecutorController` or `WatcherTimerController`.
+`WatcherSingleton` is **deprecated** and its push methods have been removed; new code should use the controllers above. See the [Watcher documentation in the Wiki](https://github.com/useful-toys/slf4j-toys/wiki/Watcher) for details and use cases.
 
 ## How slf4j-toys Solves It with Semantic Logging
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,52 @@ The library introduces:
 *   **Watcher**: For reporting the state of the Java runtime and underlying infrastructure.
 *   **Reporter**: For generating diagnostic reports.
 
+## Watcher
+
+The `Watcher` component periodically reports the state of the JVM and the underlying platform. It is designed for **instance-based lifecycle management**: each push mechanism (`ScheduledExecutorService` or `Timer`) is wrapped by its own controller, which owns a dedicated `Watcher` instance.
+
+### Push controllers
+
+Use `WatcherExecutorController` or `WatcherTimerController` to schedule automatic reports. Both read `WatcherConfig` defaults (`name`, `delay`, `period`) when created, and expose `create()` shortcuts plus a fluent `Builder` for customization.
+
+```java
+// Defaults from WatcherConfig (name="watcher", delay=1m, period=10m)
+try (WatcherExecutorController controller = WatcherExecutorController.create()) {
+    controller.start();
+    // runs until the application shuts down or stop()/close() is called
+}
+
+// Custom name and schedule
+WatcherTimerController timer = WatcherTimerController.create("myapp", 30_000, 60_000);
+timer.start();
+
+// Full builder flexibility
+WatcherExecutorController controller = WatcherExecutorController.builder()
+    .name("ops")
+    .delayMilliseconds(5_000)
+    .periodMilliseconds(30_000)
+    .build();
+controller.start();
+```
+
+The controllers use **daemon threads** named after the watcher, so they do not block JVM shutdown.
+
+### Configuration
+
+All defaults are read from `WatcherConfig`, which is populated from system properties at class-load time:
+
+| Property | Default | Description |
+|---|---|---|
+| `slf4jtoys.watcher.name` | `watcher` | Logger/thread name used by the default watcher. |
+| `slf4jtoys.watcher.delay` | `60000` | Initial delay before the first report. |
+| `slf4jtoys.watcher.period` | `600000` | Interval between reports. |
+
+You may also set `WatcherConfig` fields programmatically before creating a controller; values are captured at build time.
+
+### Legacy `WatcherSingleton`
+
+`WatcherSingleton` is **deprecated** and now only provides the default `Watcher` instance for the servlet pull path. Its push methods (`startDefaultWatcherExecutor`, `startDefaultWatcherTimer`) have been removed; migrate to `WatcherExecutorController` or `WatcherTimerController`.
+
 ## How slf4j-toys Solves It with Semantic Logging
 
 *slf4j-toys* fills the gap of ambiguous standard logging by providing a clear **Life Cycle** for every operation, offering tools that create clear, structured, and machine-readable log messages.

--- a/doc/TDR-0005-robust-and-minimalist-configuration-mechanism.md
+++ b/doc/TDR-0005-robust-and-minimalist-configuration-mechanism.md
@@ -46,7 +46,7 @@ We implemented a centralized configuration mechanism based on **System Propertie
 
 **Negative**:
 *   **Global State**: Configuration is global to the JVM session, which might be a limitation in complex multi-tenant environments (though this is typical for logging libraries).
-*   **Static Initialization Limitation**: Some components (e.g., `WatcherSingleton`, `WatcherServlet`) use static initialization to create singletons based on the initial system property values. Consequently, programmatic changes to configuration classes or calls to `init()`/`reset()` made *after* these singletons are initialized will not be reflected in their behavior. This is a known technical debt that will require refactoring in the future.
+*   **Static Initialization Limitation**: Some components (e.g., `WatcherServlet`, and the remaining `WatcherSingleton.getDefaultWatcher()` pull path) use static initialization to create a singleton based on the initial system property values. Consequently, programmatic changes to configuration classes or calls to `init()`/`reset()` made *after* these singletons are initialized will not be reflected in their behavior. The push side of `WatcherSingleton` was removed in [TDR-0036](./TDR-0036-replace-watcher-singleton-push-with-controllers.md); the remaining pull path is provisional technical debt to be addressed when the servlet is migrated.
 *   **Manual Sync**: Adding a new property requires updating the config class, the `init()` method, and the documentation.
 
 **Neutral**:

--- a/doc/TDR-0008-flexible-execution-strategies-push-vs-pull.md
+++ b/doc/TDR-0008-flexible-execution-strategies-push-vs-pull.md
@@ -19,10 +19,10 @@ We decided to implement a **Multi-Strategy Execution Model** that supports both 
 Both `Watcher` and `Reporter` classes implement `java.lang.Runnable`. They contain no internal scheduling logic. This makes them "passive" components that can be plugged into any scheduling framework (Spring, EJB Timer, Quartz, custom application schedulers, or any other execution mechanism that accepts `Runnable` instances).
 
 ### 2. Push Strategy (Internal Scheduling)
-For simple architectures, `WatcherSingleton` provides a built-in "Push" mechanism:
-*   **`startDefaultWatcherExecutor()`**: Uses a `ScheduledExecutorService` to push reports at fixed intervals.
-*   **`startDefaultWatcherTimer()`**: Uses a legacy `java.util.Timer` for environments where a full executor is not desired.
-*   **Rationale**: Provides a "zero-config" way to get monitoring running in standalone apps.
+For simple architectures, two instance-based controllers provide a built-in "Push" mechanism:
+*   **`WatcherExecutorController`**: Uses a `ScheduledExecutorService` to push reports at fixed intervals.
+*   **`WatcherTimerController`**: Uses a legacy `java.util.Timer` for environments where a full executor is not desired.
+*   **Rationale**: Provides a "zero-config" way to get monitoring running in standalone apps while giving the application explicit ownership of the watcher instance and its lifecycle. Both controllers read `WatcherConfig` defaults when created and expose `create()` shortcuts plus a fluent `Builder`.
 
 ### 3. Pull Strategy (External Triggers)
 For managed or probe-based environments, we provide a "Pull" mechanism via Servlets:
@@ -42,11 +42,11 @@ For managed or probe-based environments, we provide a "Pull" mechanism via Servl
 *   **Flexibility**: Users can choose the strategy that best fits their operational model (e.g., fixed interval vs. on-demand).
 
 **Negative**:
-*   **Configuration Fragmentation**: Users must understand which strategy is appropriate for their environment (e.g., not using `WatcherSingleton`'s executor in a JavaEE app).
+*   **Configuration Fragmentation**: Users must understand which strategy is appropriate for their environment (e.g., not using the built-in push controllers in a JavaEE app that manages its own threads).
 *   **Security Surface**: The "Pull" strategy (Servlets) introduces a new HTTP endpoint that must be manually secured by the user to prevent information disclosure or DoS.
 
 **Neutral**:
-*   **Static Initialization Dependency**: As noted in [TDR-0005](./TDR-0005-robust-and-minimalist-configuration-mechanism.md), the `WatcherSingleton` and `WatcherServlet` rely on the default instance, which captures configuration at class-loading time.
+*   **Static Initialization Dependency**: As noted in [TDR-0005](./TDR-0005-robust-and-minimalist-configuration-mechanism.md), the remaining `WatcherSingleton.getDefaultWatcher()` pull path and `WatcherServlet` rely on the default instance, which captures configuration at class-loading time. The new push controllers capture `WatcherConfig` values when the controller is built, avoiding the static singleton limitation.
 
 ## Alternatives
 
@@ -58,15 +58,19 @@ For managed or probe-based environments, we provide a "Pull" mechanism via Servl
 ## Implementation
 
 *   `Watcher` and `Reporter` implement `Runnable`, making them compatible with any scheduling or execution mechanism that accepts `Runnable` instances.
-*   `WatcherSingleton` manages the lifecycle of the default instance and its optional internal executors.
+*   `WatcherExecutorController` and `WatcherTimerController` manage instance-based push execution; each owns a dedicated `Watcher` created from `WatcherConfig` at build time.
+*   `WatcherSingleton` is `@Deprecated` and now only provides the default `Watcher` instance for the servlet pull path.
 *   `WatcherServlet` (Jakarta) and `WatcherJavaxServlet` (Legacy) provide the HTTP bridge for Watcher.
 *   `ReporterServlet` (Jakarta) and `ReporterJavaxServlet` (Legacy) provide the HTTP bridge for Reporter.
 
 ## References
 
 *   [Watcher.java](../src/main/java/org/usefultoys/slf4j/watcher/Watcher.java)
+*   [WatcherExecutorController.java](../src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java)
+*   [WatcherTimerController.java](../src/main/java/org/usefultoys/slf4j/watcher/WatcherTimerController.java)
 *   [WatcherSingleton.java](../src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java)
 *   [WatcherServlet.java](../src/main/java/org/usefultoys/slf4j/watcher/WatcherServlet.java)
 *   [Wiki: JavaEE Use Case](../slf4j-toys.wiki/watcher/Watcher-use-case-javaee.md)
 *   [Wiki: Spring Boot Use Case](../slf4j-toys.wiki/watcher/Watcher-use-case-spring-boot.md)
 *   [TDR-0005: Robust and Minimalist Configuration Mechanism](./TDR-0005-robust-and-minimalist-configuration-mechanism.md)
+*   [TDR-0036: Replace WatcherSingleton Push with Instance-Based Controllers](./TDR-0036-replace-watcher-singleton-push-with-controllers.md)

--- a/doc/TDR-0012-watcher-singleton-regret.md
+++ b/doc/TDR-0012-watcher-singleton-regret.md
@@ -1,13 +1,14 @@
 # TDR-0012: Watcher Singleton Implementation Regret
 
-**Status**: Accepted (Technical Debt)
+**Status**: Superseded (push resolved by [TDR-0036](./TDR-0036-replace-watcher-singleton-push-with-controllers.md); pull path still provisional)
 **Date**: 2026-01-03
+**Updated**: 2026-07-07
 
 ## Context
 The `Watcher` component was designed to monitor system resources and application health. To simplify its usage in standard applications, a `WatcherSingleton` was implemented to provide a globally accessible, default instance that could be easily started and stopped via a background executor or timer.
 
-## Decision
-We implemented `WatcherSingleton` as a utility class (using Lombok's `@UtilityClass`) that lazily initializes a single `Watcher` instance and manages its lifecycle (start/stop) using either a `ScheduledExecutorService` or a `Timer`.
+## Decision (Historical)
+We originally implemented `WatcherSingleton` as a utility class (using Lombok's `@UtilityClass`) that lazily initializes a single `Watcher` instance and manages its lifecycle (start/stop) using either a `ScheduledExecutorService` or a `Timer`.
 
 ## Consequences
 **Positive**:
@@ -20,14 +21,20 @@ We implemented `WatcherSingleton` as a utility class (using Lombok's `@UtilityCl
 *   **Lifecycle Issues**: In containerized or modular environments (like JavaEE/JakartaEE), static singletons can lead to memory leaks if not properly shut down, as they are tied to the ClassLoader's lifecycle.
 *   **Hidden Dependencies**: Classes using `WatcherSingleton` have a hidden dependency on a global state, making the code harder to reason about and refactor.
 
+## Resolution
+In [TDR-0036](./TDR-0036-replace-watcher-singleton-push-with-controllers.md), the push side of `WatcherSingleton` was removed and replaced by instance-based `WatcherExecutorController` and `WatcherTimerController`. `WatcherSingleton` now only provides the default `Watcher` instance for the servlet pull path (`WatcherServlet` / `WatcherJavaxServlet`) and is marked `@Deprecated`.
+
+The negative consequences above no longer apply to push execution. They still apply to the remaining `getDefaultWatcher()` pull path until the servlet is migrated to use its own `Watcher` instance.
+
 ## Alternatives
 *   **Dependency Injection**: Instead of a singleton, the `Watcher` could be injected into components that need it. This would solve the testing and configuration issues but would require a DI framework or more boilerplate code.
 *   **Instance Management**: Allow the creation of multiple `Watcher` instances and let the application manage them. The "default" instance could be managed by the application's lifecycle container rather than a static singleton.
 
 ## Implementation
-The current implementation remains in [src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java](src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java) for backward compatibility, but it is considered technical debt. Future versions should favor instance-based management and dependency injection.
+The push implementation was removed from [src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java](src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java). The class now only retains `getDefaultWatcher()` as a temporary compatibility bridge for the servlet pull path. New code should use `WatcherExecutorController`, `WatcherTimerController`, or create a dedicated `Watcher` instance.
 
 ## References
 *   [src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java](src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java)
 *   [src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java](src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java)
 *   [doc/TDR-0005-configuration-mechanism.md](doc/TDR-0005-configuration-mechanism.md)
+*   [doc/TDR-0036-replace-watcher-singleton-push-with-controllers.md](./TDR-0036-replace-watcher-singleton-push-with-controllers.md)

--- a/doc/TDR-0036-replace-watcher-singleton-push-with-controllers.md
+++ b/doc/TDR-0036-replace-watcher-singleton-push-with-controllers.md
@@ -23,7 +23,7 @@ Each controller:
 
 *   Owns its own `Watcher` instance, created at construction time from the configured `name`.
 *   Reads defaults from `WatcherConfig` (`name`, `delayMilliseconds`, `periodMilliseconds`) when the builder or `create()` is invoked (late creation).
-*   Provides `create()` static shortcuts and a fluent `Builder`.
+*   Provides `create()` static factory methods only.
 *   Implements `AutoCloseable` for safe lifecycle management.
 *   Uses a daemon thread named after the watcher, fixing the shutdown-blocking issue.
 
@@ -47,7 +47,7 @@ Each controller:
 
 *   **Keep `WatcherSingleton` as an adapter delegating to controllers**: rejected because the user requested removing the maximum from `WatcherSingleton`; keeping dead push methods would perpetuate the deprecated API.
 *   **Introduce a common `WatcherController` interface**: rejected; the two controllers are simple enough to remain standalone `AutoCloseable` classes.
-*   **Use Lombok `@Builder`**: attempted. Lombok 1.18.46 cannot cleanly exclude internal lifecycle fields (`executor`, `task`, `timer`, `timerTask`) from the generated builder, nor does it support default values on constructor parameters in this Java-8-compatible codebase. A hand-written `Builder` was chosen instead; it remains fluent and captures `WatcherConfig` defaults at builder-creation time.
+*   **Use Lombok `@Builder`**: rejected. The project style guide (`java.instructions.md`) forbids `@Builder`. A private constructor plus static `create(...)` factory methods provides the same late-binding of `WatcherConfig` defaults with less generated code and no Lombok builders.
 
 ## Implementation
 

--- a/doc/TDR-0036-replace-watcher-singleton-push-with-controllers.md
+++ b/doc/TDR-0036-replace-watcher-singleton-push-with-controllers.md
@@ -1,0 +1,70 @@
+# TDR-0036: Replace WatcherSingleton Push with Instance-Based Controllers
+
+**Status**: Accepted
+**Date**: 2026-07-07
+
+## Context
+
+`WatcherSingleton` (TDR-0012) provided a global default `Watcher` and static methods to start/stop periodic push execution via `ScheduledExecutorService` or `Timer`. This design created well-documented problems:
+
+*   **Configuration rigidity**: the cached `Watcher` instance captured `WatcherConfig` values at first access, ignoring later changes (`.glm-findings/02`).
+*   **Concurrency race**: the same `Watcher` instance could be invoked concurrently by the executor thread, the timer thread and HTTP servlet threads (`.glm-findings/03`).
+*   **Lifecycle leaks**: the `Timer` was non-daemon, blocking JVM shutdown if `stopDefaultWatcherTimer()` was not called (`.glm-findings/05`).
+*   **Hidden global state**: callers depended on a static singleton instead of an explicit instance (TDR-0005, TDR-0012).
+
+## Decision
+
+Replace the push side of `WatcherSingleton` with two first-class, instance-based controllers:
+
+*   `WatcherExecutorController` — uses `ScheduledExecutorService`.
+*   `WatcherTimerController` — uses `Timer`.
+
+Each controller:
+
+*   Owns its own `Watcher` instance, created at construction time from the configured `name`.
+*   Reads defaults from `WatcherConfig` (`name`, `delayMilliseconds`, `periodMilliseconds`) when the builder or `create()` is invoked (late creation).
+*   Provides `create()` static shortcuts and a fluent `Builder`.
+*   Implements `AutoCloseable` for safe lifecycle management.
+*   Uses a daemon thread named after the watcher, fixing the shutdown-blocking issue.
+
+`WatcherSingleton` is reduced to the minimum needed by `WatcherServlet`/`WatcherJavaxServlet` (pull): only `getDefaultWatcher()` remains, marked `@Deprecated`.
+
+## Consequences
+
+**Positive**:
+
+*   **Explicit lifecycle**: the application owns controller instances, eliminating hidden global-state dependencies.
+*   **Testability**: each test creates independent controllers; there is no shared singleton state to leak.
+*   **Configuration flexibility**: `WatcherConfig` can be changed before building a controller; each controller snapshots the config values it needs.
+*   **Race elimination**: push controllers no longer share a `Watcher` instance with each other or with the servlet pull path.
+*   **Resource safety**: daemon threads and `AutoCloseable` reduce the risk of blocking shutdown or leaking schedulers.
+
+**Negative / Breaking**:
+
+*   Callers of `WatcherSingleton.startDefaultWatcherExecutor()` and `WatcherSingleton.startDefaultWatcherTimer()` must migrate to `WatcherExecutorController.create().start()` / `WatcherTimerController.create().start()`. This is an intentional breaking change for a deprecated API.
+
+## Alternatives Considered
+
+*   **Keep `WatcherSingleton` as an adapter delegating to controllers**: rejected because the user requested removing the maximum from `WatcherSingleton`; keeping dead push methods would perpetuate the deprecated API.
+*   **Introduce a common `WatcherController` interface**: rejected; the two controllers are simple enough to remain standalone `AutoCloseable` classes.
+*   **Use Lombok `@Builder`**: attempted. Lombok 1.18.46 cannot cleanly exclude internal lifecycle fields (`executor`, `task`, `timer`, `timerTask`) from the generated builder, nor does it support default values on constructor parameters in this Java-8-compatible codebase. A hand-written `Builder` was chosen instead; it remains fluent and captures `WatcherConfig` defaults at builder-creation time.
+
+## Implementation
+
+*   New classes: `src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java`, `WatcherTimerController.java`.
+*   Reduced class: `src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java`.
+*   New tests: `src/test/java/org/usefultoys/slf4j/watcher/WatcherExecutorControllerTest.java`, `WatcherTimerControllerTest.java`.
+*   Slimmed test: `src/test/java/org/usefultoys/slf4j/watcher/WatcherSingletonTest.java`.
+*   Documentation: updated `README.md` and this TDR.
+
+## References
+
+*   [src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java](../src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java)
+*   [src/main/java/org/usefultoys/slf4j/watcher/WatcherTimerController.java](../src/main/java/org/usefultoys/slf4j/watcher/WatcherTimerController.java)
+*   [src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java](../src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java)
+*   [doc/TDR-0012-watcher-singleton-regret.md](./TDR-0012-watcher-singleton-regret.md)
+*   [doc/TDR-0008-flexible-execution-strategies-push-vs-pull.md](./TDR-0008-flexible-execution-strategies-push-vs-pull.md)
+*   [doc/TDR-0005-robust-and-minimalist-configuration-mechanism.md](./TDR-0005-robust-and-minimalist-configuration-mechanism.md)
+*   `.glm-findings/02-watcher-caches-dataEnabled.md`
+*   `.glm-findings/03-watcher-run-thread-safety.md`
+*   `.glm-findings/05-watchersingleton-timer-non-daemon.md`

--- a/plan/avoid-watcher-singleton.md
+++ b/plan/avoid-watcher-singleton.md
@@ -1,7 +1,13 @@
-# Plano: Avoid Watcher Singleton — Controllers de Push com Lombok `@Builder`
+# Plano: Avoid Watcher Singleton — Controllers de Push com Builder
 
 **Branch:** `feature/avoid-watcher-singleton`
 **Fase:** 1 (push) — pull (servlet) fica para fase posterior
+
+> **Nota de implementação:** o plano original previa o uso de Lombok `@Builder`.
+> Na versão 1.18.46 não há `@Builder.Ignore` e não é possível definir defaults em
+> parâmetros de construtor de forma compatível com Java 8. A implementação final
+> usa um `Builder` escrito manualmente, ainda fluente e com defaults de
+> `WatcherConfig`.
 
 ## Contexto
 

--- a/plan/avoid-watcher-singleton.md
+++ b/plan/avoid-watcher-singleton.md
@@ -1,0 +1,228 @@
+# Plano: Avoid Watcher Singleton — Controllers de Push com Lombok `@Builder`
+
+**Branch:** `feature/avoid-watcher-singleton`
+**Fase:** 1 (push) — pull (servlet) fica para fase posterior
+
+## Contexto
+
+`WatcherSingleton` (TDR-0012) é dívida técnica assumida: fornece um `Watcher` default globalmente acessível e métodos `startDefaultWatcherExecutor`/`startDefaultWatcherTimer`/`stop...` para agendamento push. Os defeitos documentados:
+
+- `.glm-findings/02` — `dataEnabled` em runtime sem efeito (instância cached uma vez).
+- `.glm-findings/03` — race: scheduler thread e servlet thread chamam `run()` no mesmo `Watcher`.
+- `.glm-findings/05` — `Timer` non-daemon bloqueia shutdown da JVM.
+- TDR-0005 — "Static Initialization Limitation": config mudada após a criação do singleton não surte efeito.
+- TDR-0008 — distingue push (agendado) de pull (sob demanda, via servlet).
+
+## Objetivos
+
+- Substituir os mecanismos de **push** do `WatcherSingleton` por **dois controllers instanciáveis**, um por tecnologia (`ScheduledExecutorService`, `Timer`).
+- Cada controller **detém sua própria instância de `Watcher`**, criada no construtor a partir de `name`.
+- Defaults vindos de `WatcherConfig` (`name`, `delayMilliseconds`, `periodMilliseconds`), overridáveis.
+- Facilidade de uso: `create()` estáticos como atalho ao builder Lombok `@Builder`.
+- `WatcherSingleton` reduzido ao **mínimo** necessário ao servlet (pull), `@Deprecated`, transitório.
+
+## Não objetivos (desta fase)
+
+- Migração do `WatcherServlet`/`WatcherJavaxServlet` (pull) — fase posterior.
+- Interface comum `WatcherController` — decidido: duas classes soltas, cada uma `implements AutoCloseable`.
+- Aceitar `Watcher` pré-construído no builder — decidido: só `name` (controller cria e detém o watcher).
+
+## Classes novas em `src/main/java/org/usefultoys/slf4j/watcher/`
+
+### `WatcherExecutorController`
+
+```java
+@lombok.Builder
+public final class WatcherExecutorController implements AutoCloseable {
+    private final Watcher watcher;
+    private final long delayMilliseconds;
+    private final long periodMilliseconds;
+    private ScheduledExecutorService executor;
+    private ScheduledFuture<?> task;
+
+    @Builder
+    public WatcherExecutorController(
+            @Builder.Default String name = WatcherConfig.name,
+            @Builder.Default long delayMilliseconds = WatcherConfig.delayMilliseconds,
+            @Builder.Default long periodMilliseconds = WatcherConfig.periodMilliseconds) {
+        this.watcher = new Watcher(name);
+        this.delayMilliseconds = delayMilliseconds;
+        this.periodMilliseconds = periodMilliseconds;
+    }
+
+    public static WatcherExecutorController create() {
+        return builder().build();
+    }
+
+    public static WatcherExecutorController create(String name) {
+        return builder().name(name).build();
+    }
+
+    public static WatcherExecutorController create(String name, long delay, long period) {
+        return builder().name(name).delay(delay).period(period).build();
+    }
+
+    public synchronized void start() {
+        if (executor == null) {
+            executor = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, name);
+                t.setDaemon(true);
+                return t;
+            });
+        }
+        if (task == null) {
+            task = executor.scheduleAtFixedRate(
+                    watcher, delayMilliseconds, periodMilliseconds, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    public synchronized void stop() {
+        if (task != null) {
+            task.cancel(true);
+            task = null;
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+            executor = null;
+        }
+    }
+
+    public synchronized boolean isRunning() {
+        return task != null;
+    }
+
+    @Override
+    public void close() {
+        stop();
+    }
+}
+```
+
+### `WatcherTimerController`
+
+Mesmo shape, com `Timer` daemon nomeado com `name` (fix `.glm-findings/05`):
+
+```java
+@lombok.Builder
+public final class WatcherTimerController implements AutoCloseable {
+    private final Watcher watcher;
+    private final long delayMilliseconds;
+    private final long periodMilliseconds;
+    private Timer timer;
+    private TimerTask timerTask;
+
+    @Builder
+    public WatcherTimerController(
+            @Builder.Default String name = WatcherConfig.name,
+            @Builder.Default long delayMilliseconds = WatcherConfig.delayMilliseconds,
+            @Builder.Default long periodMilliseconds = WatcherConfig.periodMilliseconds) {
+        this.watcher = new Watcher(name);
+        this.delayMilliseconds = delayMilliseconds;
+        this.periodMilliseconds = periodMilliseconds;
+    }
+
+    public static WatcherTimerController create() {
+        return builder().build();
+    }
+
+    public static WatcherTimerController create(String name) {
+        return builder().name(name).build();
+    }
+
+    public static WatcherTimerController create(String name, long delay, long period) {
+        return builder().name(name).delay(delay).period(period).build();
+    }
+
+    public synchronized void start() {
+        if (timer == null) {
+            timer = new Timer(name, true);
+        }
+        if (timerTask == null) {
+            timerTask = new TimerTask() {
+                @Override
+                public void run() {
+                    watcher.run();
+                }
+            };
+            timer.schedule(timerTask, delayMilliseconds, periodMilliseconds);
+        }
+    }
+
+    public synchronized void stop() {
+        if (timerTask != null) {
+            timerTask = null;
+        }
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
+    }
+
+    public synchronized boolean isRunning() {
+        return timerTask != null;
+    }
+
+    @Override
+    public void close() {
+        stop();
+    }
+}
+```
+
+### Nome das threads
+
+Timer e thread do executor recebem **exatamente `name`** (ex.: "watcher" no default, "myapp" se override). Alinha thread dump ↔ logger ↔ watcher. Diferente do original, que usava "Watcher" fixo (Timer) e "pool-N-thread-M" (executor).
+
+## `WatcherSingleton` — máximo de remoção
+
+```java
+@UtilityClass
+@Deprecated
+public final class WatcherSingleton {
+    private static Watcher DEFAULT_WATCHER_INSTANCE;
+
+    @Deprecated
+    public static synchronized Watcher getDefaultWatcher() {
+        if (DEFAULT_WATCHER_INSTANCE == null) {
+            DEFAULT_WATCHER_INSTANCE = new Watcher(WatcherConfig.name);
+        }
+        return DEFAULT_WATCHER_INSTANCE;
+    }
+}
+```
+
+- **Removidos:** `startDefaultWatcherExecutor`, `stopDefaultWatcherExecutor`, `startDefaultWatcherTimer`, `stopDefaultWatcherTimer` + campos `defaultWatcherExecutor`, `scheduledDefaultWatcher`, `defaultWatcherTimer`, `defaultWatcherTask`.
+- **Mantido:** só `getDefaultWatcher()` (pull — `WatcherServlet.runWatcher()` e `WatcherJavaxServlet.runWatcher()` continuam chamando), `@Deprecated`, transitório até o servlet ser migrado.
+- Javadoc reescrito: de "manages periodic execution" para "provides the default Watcher instance for pull-mode (servlet)".
+- **Breaking para callers de push:** quem chamava `WatcherSingleton.startDefaultWatcherExecutor()` migra para `WatcherExecutorController.create().start()`; `startDefaultWatcherTimer()` → `WatcherTimerController.create().start()`.
+
+## Semântica "late creation"
+
+`@Builder.Default` lê `WatcherConfig` no momento da chamada a `builder()` (ou `create()`). A aplicação seta config antes, e nada é materializado no startup da biblioteca. O `Watcher` só nasce no `build()`/`create()`, a partir do `name` capturado.
+
+## Testes (`src/test/java/org/usefultoys/slf4j/watcher/`)
+
+- **Novos** `WatcherExecutorControllerTest`, `WatcherTimerControllerTest`: portar os casos de push do `WatcherSingletonTest` — idempotência start/stop, logging via Awaitility, instância própria de `Watcher` por controller, defaults do `WatcherConfig`, overrides via `create()` e builder, `close()`/try-with-resources, thread daemon + nome = `name`.
+- `WatcherSingletonTest` **slimmed**: só `getDefaultWatcher()` (lazy cache, nome de `WatcherConfig`); casos de push removidos (migrados para os controllers).
+- `WatcherServletTest`, `WatcherTest`, `WatcherConfigTest`: **intocados**.
+
+## Documentação
+
+- `README.md`: nova seção "Watcher" com `create()` + builder + try-with-resources.
+- Novo TDR "Watcher Controller substitui push do WatcherSingleton" — revoga o lado push do TDR-0012.
+- TDR-0005: marcar "Static Initialization Limitation" do push como resolvido; pull (servlet via `getDefaultWatcher()`) pendente.
+- `.glm-findings/02`, `03`, `05`: marcar resolvidos no push.
+
+## Pré-execução (trunk-based)
+
+Criar branch/worktree `feature/avoid-watcher-singleton` a partir de `main` atualizada. Não editar em `main`.
+
+## Verificação (pós-implementação)
+
+```
+mvnw.cmd -B -Pslf4j-2.0 test
+mvnw.cmd -B -Pslf4j-2.0,with-logback test
+mvnw.cmd -B -Pslf4j-1.7-javax test
+```
+
+Perfil `jdk-8` auto (compatibilidade Java 8). CI: Qodana/CodeQL.

--- a/plan/avoid-watcher-singleton.md
+++ b/plan/avoid-watcher-singleton.md
@@ -1,13 +1,11 @@
-# Plano: Avoid Watcher Singleton — Controllers de Push com Builder
+# Plano: Avoid Watcher Singleton — Controllers de Push com Factory Methods
 
 **Branch:** `feature/avoid-watcher-singleton`
 **Fase:** 1 (push) — pull (servlet) fica para fase posterior
 
-> **Nota de implementação:** o plano original previa o uso de Lombok `@Builder`.
-> Na versão 1.18.46 não há `@Builder.Ignore` e não é possível definir defaults em
-> parâmetros de construtor de forma compatível com Java 8. A implementação final
-> usa um `Builder` escrito manualmente, ainda fluente e com defaults de
-> `WatcherConfig`.
+> **Nota de implementação:** não usa Lombok `@Builder` (proibido pelo guia de
+> estilo). Cada controller expõe apenas métodos factory estáticos `create(...)`
+> que leem os defaults de `WatcherConfig` no momento da chamada.
 
 ## Contexto
 
@@ -24,156 +22,71 @@
 - Substituir os mecanismos de **push** do `WatcherSingleton` por **dois controllers instanciáveis**, um por tecnologia (`ScheduledExecutorService`, `Timer`).
 - Cada controller **detém sua própria instância de `Watcher`**, criada no construtor a partir de `name`.
 - Defaults vindos de `WatcherConfig` (`name`, `delayMilliseconds`, `periodMilliseconds`), overridáveis.
-- Facilidade de uso: `create()` estáticos como atalho ao builder Lombok `@Builder`.
+- Facilidade de uso: métodos factory estáticos `create()`.
 - `WatcherSingleton` reduzido ao **mínimo** necessário ao servlet (pull), `@Deprecated`, transitório.
 
 ## Não objetivos (desta fase)
 
 - Migração do `WatcherServlet`/`WatcherJavaxServlet` (pull) — fase posterior.
 - Interface comum `WatcherController` — decidido: duas classes soltas, cada uma `implements AutoCloseable`.
-- Aceitar `Watcher` pré-construído no builder — decidido: só `name` (controller cria e detém o watcher).
+- Aceitar `Watcher` pré-construído — decidido: só `name` (controller cria e detém o watcher).
+- Builder Lombok ou manual — decidido: não usar builder.
 
 ## Classes novas em `src/main/java/org/usefultoys/slf4j/watcher/`
 
 ### `WatcherExecutorController`
 
 ```java
-@lombok.Builder
 public final class WatcherExecutorController implements AutoCloseable {
-    private final Watcher watcher;
+    private final String name;
     private final long delayMilliseconds;
     private final long periodMilliseconds;
+    private final Watcher watcher;
+
     private ScheduledExecutorService executor;
     private ScheduledFuture<?> task;
 
-    @Builder
-    public WatcherExecutorController(
-            @Builder.Default String name = WatcherConfig.name,
-            @Builder.Default long delayMilliseconds = WatcherConfig.delayMilliseconds,
-            @Builder.Default long periodMilliseconds = WatcherConfig.periodMilliseconds) {
-        this.watcher = new Watcher(name);
+    private WatcherExecutorController(
+            final String name,
+            final long delayMilliseconds,
+            final long periodMilliseconds) {
+        this.name = name;
         this.delayMilliseconds = delayMilliseconds;
         this.periodMilliseconds = periodMilliseconds;
+        this.watcher = new Watcher(name);
     }
 
     public static WatcherExecutorController create() {
-        return builder().build();
+        return new WatcherExecutorController(
+                WatcherConfig.name,
+                WatcherConfig.delayMilliseconds,
+                WatcherConfig.periodMilliseconds);
     }
 
-    public static WatcherExecutorController create(String name) {
-        return builder().name(name).build();
+    public static WatcherExecutorController create(final String name) {
+        return new WatcherExecutorController(
+                name,
+                WatcherConfig.delayMilliseconds,
+                WatcherConfig.periodMilliseconds);
     }
 
-    public static WatcherExecutorController create(String name, long delay, long period) {
-        return builder().name(name).delay(delay).period(period).build();
+    public static WatcherExecutorController create(
+            final String name,
+            final long delayMilliseconds,
+            final long periodMilliseconds) {
+        return new WatcherExecutorController(name, delayMilliseconds, periodMilliseconds);
     }
 
-    public synchronized void start() {
-        if (executor == null) {
-            executor = Executors.newSingleThreadScheduledExecutor(r -> {
-                Thread t = new Thread(r, name);
-                t.setDaemon(true);
-                return t;
-            });
-        }
-        if (task == null) {
-            task = executor.scheduleAtFixedRate(
-                    watcher, delayMilliseconds, periodMilliseconds, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    public synchronized void stop() {
-        if (task != null) {
-            task.cancel(true);
-            task = null;
-        }
-        if (executor != null) {
-            executor.shutdownNow();
-            executor = null;
-        }
-    }
-
-    public synchronized boolean isRunning() {
-        return task != null;
-    }
-
-    @Override
-    public void close() {
-        stop();
-    }
+    public synchronized void start() { /* daemon executor, thread name = name */ }
+    public synchronized void stop() {}
+    public synchronized boolean isRunning() { return task != null; }
+    @Override public void close() { stop(); }
 }
 ```
 
 ### `WatcherTimerController`
 
-Mesmo shape, com `Timer` daemon nomeado com `name` (fix `.glm-findings/05`):
-
-```java
-@lombok.Builder
-public final class WatcherTimerController implements AutoCloseable {
-    private final Watcher watcher;
-    private final long delayMilliseconds;
-    private final long periodMilliseconds;
-    private Timer timer;
-    private TimerTask timerTask;
-
-    @Builder
-    public WatcherTimerController(
-            @Builder.Default String name = WatcherConfig.name,
-            @Builder.Default long delayMilliseconds = WatcherConfig.delayMilliseconds,
-            @Builder.Default long periodMilliseconds = WatcherConfig.periodMilliseconds) {
-        this.watcher = new Watcher(name);
-        this.delayMilliseconds = delayMilliseconds;
-        this.periodMilliseconds = periodMilliseconds;
-    }
-
-    public static WatcherTimerController create() {
-        return builder().build();
-    }
-
-    public static WatcherTimerController create(String name) {
-        return builder().name(name).build();
-    }
-
-    public static WatcherTimerController create(String name, long delay, long period) {
-        return builder().name(name).delay(delay).period(period).build();
-    }
-
-    public synchronized void start() {
-        if (timer == null) {
-            timer = new Timer(name, true);
-        }
-        if (timerTask == null) {
-            timerTask = new TimerTask() {
-                @Override
-                public void run() {
-                    watcher.run();
-                }
-            };
-            timer.schedule(timerTask, delayMilliseconds, periodMilliseconds);
-        }
-    }
-
-    public synchronized void stop() {
-        if (timerTask != null) {
-            timerTask = null;
-        }
-        if (timer != null) {
-            timer.cancel();
-            timer = null;
-        }
-    }
-
-    public synchronized boolean isRunning() {
-        return timerTask != null;
-    }
-
-    @Override
-    public void close() {
-        stop();
-    }
-}
-```
+Mesmo shape, com `Timer` daemon nomeado com `name` (fix `.glm-findings/05`).
 
 ### Nome das threads
 
@@ -204,17 +117,17 @@ public final class WatcherSingleton {
 
 ## Semântica "late creation"
 
-`@Builder.Default` lê `WatcherConfig` no momento da chamada a `builder()` (ou `create()`). A aplicação seta config antes, e nada é materializado no startup da biblioteca. O `Watcher` só nasce no `build()`/`create()`, a partir do `name` capturado.
+`create()` lê `WatcherConfig` no momento da chamada. A aplicação seta config antes, e nada é materializado no startup da biblioteca. O `Watcher` só nasce no `create()`, a partir do `name` capturado.
 
 ## Testes (`src/test/java/org/usefultoys/slf4j/watcher/`)
 
-- **Novos** `WatcherExecutorControllerTest`, `WatcherTimerControllerTest`: portar os casos de push do `WatcherSingletonTest` — idempotência start/stop, logging via Awaitility, instância própria de `Watcher` por controller, defaults do `WatcherConfig`, overrides via `create()` e builder, `close()`/try-with-resources, thread daemon + nome = `name`.
+- **Novos** `WatcherExecutorControllerTest`, `WatcherTimerControllerTest`: portar os casos de push do `WatcherSingletonTest` — idempotência start/stop, logging via Awaitility, instância própria de `Watcher` por controller, defaults do `WatcherConfig`, overrides via `create()`, `close()`/try-with-resources, thread daemon + nome = `name`.
 - `WatcherSingletonTest` **slimmed**: só `getDefaultWatcher()` (lazy cache, nome de `WatcherConfig`); casos de push removidos (migrados para os controllers).
 - `WatcherServletTest`, `WatcherTest`, `WatcherConfigTest`: **intocados**.
 
 ## Documentação
 
-- `README.md`: nova seção "Watcher" com `create()` + builder + try-with-resources.
+- `README.md`: nova seção "Watcher" com `create()` + try-with-resources.
 - Novo TDR "Watcher Controller substitui push do WatcherSingleton" — revoga o lado push do TDR-0012.
 - TDR-0005: marcar "Static Initialization Limitation" do push como resolvido; pull (servlet via `getDefaultWatcher()`) pendente.
 - `.glm-findings/02`, `03`, `05`: marcar resolvidos no push.

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.watcher;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Periodically executes a {@link Watcher} using a {@link ScheduledExecutorService}.
+ * <p>
+ * Each controller owns its own {@link Watcher} instance, created from the configured {@code name}.
+ * By default, the controller reads {@code name}, {@code delayMilliseconds} and {@code periodMilliseconds}
+ * from {@link WatcherConfig} at the moment the builder or {@code create()} method is invoked. This allows
+ * the application to set configuration before materializing the watcher.
+ * <p>
+ * The controller exposes {@link #create()} shortcuts for the most common use cases, and a fluent
+ * {@link Builder} for full flexibility. The underlying executor uses a daemon thread named after the
+ * watcher, so it will not prevent the JVM from shutting down.
+ * <p>
+ * {@code start()} and {@code stop()} are idempotent and may be called multiple times.
+ *
+ * @author Daniel Felix Ferber
+ * @see Watcher
+ * @see WatcherConfig
+ * @see WatcherTimerController
+ */
+public final class WatcherExecutorController implements AutoCloseable {
+
+    private final String name;
+    private final long delayMilliseconds;
+    private final long periodMilliseconds;
+    private final Watcher watcher;
+
+    private ScheduledExecutorService executor;
+    private ScheduledFuture<?> task;
+
+    private WatcherExecutorController(final Builder builder) {
+        this.name = builder.name;
+        this.delayMilliseconds = builder.delayMilliseconds;
+        this.periodMilliseconds = builder.periodMilliseconds;
+        this.watcher = new Watcher(name);
+    }
+
+    /**
+     * Returns a builder pre-populated with defaults from {@link WatcherConfig}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a controller using all defaults from {@link WatcherConfig}.
+     *
+     * @return a new, not-yet-started controller
+     */
+    public static WatcherExecutorController create() {
+        return builder().build();
+    }
+
+    /**
+     * Creates a controller with a custom watcher name and default schedule from {@link WatcherConfig}.
+     *
+     * @param name logical watcher name
+     * @return a new, not-yet-started controller
+     */
+    public static WatcherExecutorController create(final String name) {
+        return builder().name(name).build();
+    }
+
+    /**
+     * Creates a controller with a custom watcher name and schedule.
+     *
+     * @param name                logical watcher name
+     * @param delayMilliseconds   initial delay before the first execution
+     * @param periodMilliseconds  interval between executions
+     * @return a new, not-yet-started controller
+     */
+    public static WatcherExecutorController create(final String name, final long delayMilliseconds, final long periodMilliseconds) {
+        return builder().name(name).delayMilliseconds(delayMilliseconds).periodMilliseconds(periodMilliseconds).build();
+    }
+
+    /**
+     * Starts periodic execution using a daemon single-thread executor.
+     * <p>
+     * Calling this method when the controller is already running has no effect.
+     */
+    public synchronized void start() {
+        if (executor == null) {
+            executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+                @Override
+                public Thread newThread(final Runnable r) {
+                    final Thread t = new Thread(r, name);
+                    t.setDaemon(true);
+                    return t;
+                }
+            });
+        }
+        if (task == null) {
+            task = executor.scheduleAtFixedRate(
+                    watcher, delayMilliseconds, periodMilliseconds, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Stops periodic execution and shuts down the executor.
+     * <p>
+     * Calling this method when the controller is already stopped has no effect.
+     */
+    public synchronized void stop() {
+        if (task != null) {
+            task.cancel(true);
+            task = null;
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+            executor = null;
+        }
+    }
+
+    /**
+     * Returns whether the controller has an active scheduled task.
+     *
+     * @return {@code true} if the watcher is scheduled, {@code false} otherwise
+     */
+    public synchronized boolean isRunning() {
+        return task != null;
+    }
+
+    /**
+     * Stops the controller. Equivalent to {@link #stop()}.
+     */
+    @Override
+    public void close() {
+        stop();
+    }
+
+    /**
+     * Fluent builder for {@link WatcherExecutorController}. Defaults are read from {@link WatcherConfig}
+     * when the builder is created, allowing the application to configure values before building.
+     */
+    public static final class Builder {
+        private String name = WatcherConfig.name;
+        private long delayMilliseconds = WatcherConfig.delayMilliseconds;
+        private long periodMilliseconds = WatcherConfig.periodMilliseconds;
+
+        private Builder() {
+            // Defaults are set above from WatcherConfig.
+        }
+
+        /**
+         * Sets the logical watcher name (and thread name).
+         *
+         * @param name logical watcher name
+         * @return this builder
+         */
+        public Builder name(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the initial delay before the first execution.
+         *
+         * @param delayMilliseconds delay in milliseconds
+         * @return this builder
+         */
+        public Builder delayMilliseconds(final long delayMilliseconds) {
+            this.delayMilliseconds = delayMilliseconds;
+            return this;
+        }
+
+        /**
+         * Sets the interval between executions.
+         *
+         * @param periodMilliseconds period in milliseconds
+         * @return this builder
+         */
+        public Builder periodMilliseconds(final long periodMilliseconds) {
+            this.periodMilliseconds = periodMilliseconds;
+            return this;
+        }
+
+        /**
+         * Builds a new controller. The owned {@link Watcher} is created from the configured name.
+         *
+         * @return a new controller
+         */
+        public WatcherExecutorController build() {
+            return new WatcherExecutorController(this);
+        }
+    }
+}

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java
@@ -25,13 +25,12 @@ import java.util.concurrent.TimeUnit;
  * Periodically executes a {@link Watcher} using a {@link ScheduledExecutorService}.
  * <p>
  * Each controller owns its own {@link Watcher} instance, created from the configured {@code name}.
- * By default, the controller reads {@code name}, {@code delayMilliseconds} and {@code periodMilliseconds}
- * from {@link WatcherConfig} at the moment the builder or {@code create()} method is invoked. This allows
- * the application to set configuration before materializing the watcher.
+ * By default, the factory methods read {@code name}, {@code delayMilliseconds} and {@code periodMilliseconds}
+ * from {@link WatcherConfig} at the moment they are called. This allows the application to set
+ * configuration before materializing the controller.
  * <p>
- * The controller exposes {@link #create()} shortcuts for the most common use cases, and a fluent
- * {@link Builder} for full flexibility. The underlying executor uses a daemon thread named after the
- * watcher, so it will not prevent the JVM from shutting down.
+ * The controller exposes {@link #create()} static factory methods for common use cases. The underlying
+ * executor uses a daemon thread named after the watcher, so it will not prevent the JVM from shutting down.
  * <p>
  * {@code start()} and {@code stop()} are idempotent and may be called multiple times.
  *
@@ -50,20 +49,18 @@ public final class WatcherExecutorController implements AutoCloseable {
     private ScheduledExecutorService executor;
     private ScheduledFuture<?> task;
 
-    private WatcherExecutorController(final Builder builder) {
-        this.name = builder.name;
-        this.delayMilliseconds = builder.delayMilliseconds;
-        this.periodMilliseconds = builder.periodMilliseconds;
-        this.watcher = new Watcher(name);
-    }
-
     /**
-     * Returns a builder pre-populated with defaults from {@link WatcherConfig}.
+     * Creates a new controller with the supplied configuration and builds the owned {@link Watcher}.
      *
-     * @return a new builder
+     * @param name                logical watcher name
+     * @param delayMilliseconds   initial delay before the first execution
+     * @param periodMilliseconds  interval between executions
      */
-    public static Builder builder() {
-        return new Builder();
+    private WatcherExecutorController(final String name, final long delayMilliseconds, final long periodMilliseconds) {
+        this.name = name;
+        this.delayMilliseconds = delayMilliseconds;
+        this.periodMilliseconds = periodMilliseconds;
+        this.watcher = new Watcher(name);
     }
 
     /**
@@ -72,7 +69,7 @@ public final class WatcherExecutorController implements AutoCloseable {
      * @return a new, not-yet-started controller
      */
     public static WatcherExecutorController create() {
-        return builder().build();
+        return new WatcherExecutorController(WatcherConfig.name, WatcherConfig.delayMilliseconds, WatcherConfig.periodMilliseconds);
     }
 
     /**
@@ -82,7 +79,7 @@ public final class WatcherExecutorController implements AutoCloseable {
      * @return a new, not-yet-started controller
      */
     public static WatcherExecutorController create(final String name) {
-        return builder().name(name).build();
+        return new WatcherExecutorController(name, WatcherConfig.delayMilliseconds, WatcherConfig.periodMilliseconds);
     }
 
     /**
@@ -94,7 +91,7 @@ public final class WatcherExecutorController implements AutoCloseable {
      * @return a new, not-yet-started controller
      */
     public static WatcherExecutorController create(final String name, final long delayMilliseconds, final long periodMilliseconds) {
-        return builder().name(name).delayMilliseconds(delayMilliseconds).periodMilliseconds(periodMilliseconds).build();
+        return new WatcherExecutorController(name, delayMilliseconds, periodMilliseconds);
     }
 
     /**
@@ -150,61 +147,5 @@ public final class WatcherExecutorController implements AutoCloseable {
     @Override
     public void close() {
         stop();
-    }
-
-    /**
-     * Fluent builder for {@link WatcherExecutorController}. Defaults are read from {@link WatcherConfig}
-     * when the builder is created, allowing the application to configure values before building.
-     */
-    public static final class Builder {
-        private String name = WatcherConfig.name;
-        private long delayMilliseconds = WatcherConfig.delayMilliseconds;
-        private long periodMilliseconds = WatcherConfig.periodMilliseconds;
-
-        private Builder() {
-            // Defaults are set above from WatcherConfig.
-        }
-
-        /**
-         * Sets the logical watcher name (and thread name).
-         *
-         * @param name logical watcher name
-         * @return this builder
-         */
-        public Builder name(final String name) {
-            this.name = name;
-            return this;
-        }
-
-        /**
-         * Sets the initial delay before the first execution.
-         *
-         * @param delayMilliseconds delay in milliseconds
-         * @return this builder
-         */
-        public Builder delayMilliseconds(final long delayMilliseconds) {
-            this.delayMilliseconds = delayMilliseconds;
-            return this;
-        }
-
-        /**
-         * Sets the interval between executions.
-         *
-         * @param periodMilliseconds period in milliseconds
-         * @return this builder
-         */
-        public Builder periodMilliseconds(final long periodMilliseconds) {
-            this.periodMilliseconds = periodMilliseconds;
-            return this;
-        }
-
-        /**
-         * Builds a new controller. The owned {@link Watcher} is created from the configured name.
-         *
-         * @return a new controller
-         */
-        public WatcherExecutorController build() {
-            return new WatcherExecutorController(this);
-        }
     }
 }

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java
@@ -17,130 +17,50 @@ package org.usefultoys.slf4j.watcher;
 
 import lombok.experimental.UtilityClass;
 
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
 /**
- * Manages the default {@link Watcher} singleton and provides methods to execute it periodically.
- * This class is suitable for simple architectures but may not be appropriate for JavaEE environments
- * that manage their own threads.
+ * Provides the default {@link Watcher} instance for pull-mode execution (e.g., {@link WatcherServlet}).
  * <p>
- * The default watcher instance is created at application startup and is named according to the system property
- * {@code slf4jtoys.watcher.name} (defaulting to "watcher"). It cannot be reassigned at runtime.
+ * This class no longer manages periodic "push" execution. For scheduled watchers, use
+ * {@link WatcherExecutorController} or {@link WatcherTimerController} instead.
  * <p>
- * This utility class offers two mechanisms for periodic execution:
- * <ul>
- *   <li>A {@link ScheduledExecutorService}-based executor.</li>
- *   <li>A {@link Timer}-based timer.</li>
- * </ul>
- * <p>
- * Note: Ensure proper lifecycle management when using this class to avoid resource leaks.
+ * The default watcher instance is created lazily upon first access and named using
+ * {@link WatcherConfig#name}. It is intended only as a temporary compatibility bridge for
+ * the servlet pull path; future versions will migrate the servlet away from this global default.
  *
+ * @deprecated Use {@link WatcherExecutorController} or {@link WatcherTimerController} for push,
+ * or create a dedicated {@link Watcher} instance for pull. This class will be removed once
+ * the servlet pull path is migrated.
  * @author Daniel Felix Ferber
  * @see Watcher
  * @see WatcherConfig
+ * @see WatcherExecutorController
+ * @see WatcherTimerController
  */
+@Deprecated
 @UtilityClass
 public final class WatcherSingleton {
 
     /**
-     * The default watcher instance. It is created lazily upon first access and named using the system property
-     * {@code slf4jtoys.watcher.name}, which defaults to "watcher".
+     * The default watcher instance. It is created lazily upon first access and named using
+     * {@link WatcherConfig#name}, which defaults to "watcher".
      */
     private static Watcher DEFAULT_WATCHER_INSTANCE;
 
     /**
      * Returns the default {@link Watcher} instance, creating it if it hasn't been initialized yet.
-     * This method ensures that {@link WatcherConfig} is initialized before the Watcher instance is created.
+     * <p>
+     * This method reads {@link WatcherConfig#name} at the moment of first access. Any runtime
+     * changes to {@link WatcherConfig#name} made after the first call will not be reflected.
      *
      * @return The default Watcher instance.
+     * @deprecated For new code, create a {@link Watcher} or use a {@link WatcherExecutorController}
+     * / {@link WatcherTimerController}.
      */
+    @Deprecated
     public static synchronized Watcher getDefaultWatcher() {
         if (DEFAULT_WATCHER_INSTANCE == null) {
             DEFAULT_WATCHER_INSTANCE = new Watcher(WatcherConfig.name);
         }
         return DEFAULT_WATCHER_INSTANCE;
-    }
-
-    /** Executor service for running the default watcher periodically. */
-    ScheduledExecutorService defaultWatcherExecutor = null;
-    ScheduledFuture<?> scheduledDefaultWatcher = null;
-
-    /** Timer for running the default watcher periodically. */
-    Timer defaultWatcherTimer = null;
-    TimerTask defaultWatcherTask = null;
-
-    /**
-     * Starts the executor that periodically invokes the default watcher to report the runtime state.
-     * This is intended for simple architectures and may not be suitable for JavaEE environments
-     * that manage their own threads.
-     */
-    public synchronized void startDefaultWatcherExecutor() {
-        if (defaultWatcherExecutor == null) {
-            defaultWatcherExecutor = Executors.newSingleThreadScheduledExecutor();
-        }
-        if (scheduledDefaultWatcher == null) {
-            scheduledDefaultWatcher = defaultWatcherExecutor.scheduleAtFixedRate(
-                    getDefaultWatcher(), // Use the getter
-                    WatcherConfig.delayMilliseconds,
-                    WatcherConfig.periodMilliseconds,
-                    TimeUnit.MILLISECONDS
-            );
-        }
-    }
-
-    /**
-     * Stops the executor that periodically invokes the default watcher.
-     */
-    public synchronized void stopDefaultWatcherExecutor() {
-        if (scheduledDefaultWatcher != null) {
-            scheduledDefaultWatcher.cancel(true);
-            scheduledDefaultWatcher = null;
-        }
-        if (defaultWatcherExecutor != null) {
-            defaultWatcherExecutor.shutdownNow();
-            defaultWatcherExecutor = null;
-        }
-    }
-
-    /**
-     * Starts the timer that periodically invokes the default watcher to report the runtime state.
-     * This is intended for simple architectures and may not be suitable for JavaEE environments
-     * that manage their own threads.
-     */
-    public synchronized void startDefaultWatcherTimer() {
-        if (defaultWatcherTimer == null) {
-            defaultWatcherTimer = new Timer("Watcher");
-        }
-        if (defaultWatcherTask == null) {
-            defaultWatcherTask = new TimerTask() {
-                @Override
-                public void run() {
-                    getDefaultWatcher().run(); // Use the getter
-                }
-            };
-            defaultWatcherTimer.schedule(
-                    defaultWatcherTask,
-                    WatcherConfig.delayMilliseconds,
-                    WatcherConfig.periodMilliseconds
-            );
-        }
-    }
-
-    /**
-     * Stops the timer that periodically invokes the default watcher.
-     */
-    public synchronized void stopDefaultWatcherTimer() {
-        if (defaultWatcherTimer != null) {
-            defaultWatcherTimer.cancel();
-            defaultWatcherTimer = null;
-        }
-        if (defaultWatcherTask != null) {
-            defaultWatcherTask = null;
-        }
     }
 }

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherTimerController.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherTimerController.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.watcher;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Periodically executes a {@link Watcher} using a {@link Timer}.
+ * <p>
+ * Each controller owns its own {@link Watcher} instance, created from the configured {@code name}.
+ * By default, the controller reads {@code name}, {@code delayMilliseconds} and {@code periodMilliseconds}
+ * from {@link WatcherConfig} at the moment the builder or {@code create()} method is invoked. This allows
+ * the application to set configuration before materializing the watcher.
+ * <p>
+ * The controller exposes {@link #create()} shortcuts for the most common use cases, and a fluent
+ * {@link Builder} for full flexibility. The underlying {@link Timer} is created as a daemon and named
+ * after the watcher, so it will not prevent the JVM from shutting down.
+ * <p>
+ * {@code start()} and {@code stop()} are idempotent and may be called multiple times.
+ *
+ * @author Daniel Felix Ferber
+ * @see Watcher
+ * @see WatcherConfig
+ * @see WatcherExecutorController
+ */
+public final class WatcherTimerController implements AutoCloseable {
+
+    private final String name;
+    private final long delayMilliseconds;
+    private final long periodMilliseconds;
+    private final Watcher watcher;
+
+    private Timer timer;
+    private TimerTask timerTask;
+
+    private WatcherTimerController(final Builder builder) {
+        this.name = builder.name;
+        this.delayMilliseconds = builder.delayMilliseconds;
+        this.periodMilliseconds = builder.periodMilliseconds;
+        this.watcher = new Watcher(name);
+    }
+
+    /**
+     * Returns a builder pre-populated with defaults from {@link WatcherConfig}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a controller using all defaults from {@link WatcherConfig}.
+     *
+     * @return a new, not-yet-started controller
+     */
+    public static WatcherTimerController create() {
+        return builder().build();
+    }
+
+    /**
+     * Creates a controller with a custom watcher name and default schedule from {@link WatcherConfig}.
+     *
+     * @param name logical watcher name
+     * @return a new, not-yet-started controller
+     */
+    public static WatcherTimerController create(final String name) {
+        return builder().name(name).build();
+    }
+
+    /**
+     * Creates a controller with a custom watcher name and schedule.
+     *
+     * @param name                logical watcher name
+     * @param delayMilliseconds   initial delay before the first execution
+     * @param periodMilliseconds  interval between executions
+     * @return a new, not-yet-started controller
+     */
+    public static WatcherTimerController create(final String name, final long delayMilliseconds, final long periodMilliseconds) {
+        return builder().name(name).delayMilliseconds(delayMilliseconds).periodMilliseconds(periodMilliseconds).build();
+    }
+
+    /**
+     * Starts periodic execution using a daemon {@link Timer} named after the watcher.
+     * <p>
+     * Calling this method when the controller is already running has no effect.
+     */
+    public synchronized void start() {
+        if (timer == null) {
+            timer = new Timer(name, true);
+        }
+        if (timerTask == null) {
+            timerTask = new TimerTask() {
+                @Override
+                public void run() {
+                    watcher.run();
+                }
+            };
+            timer.schedule(timerTask, delayMilliseconds, periodMilliseconds);
+        }
+    }
+
+    /**
+     * Stops periodic execution and cancels the timer.
+     * <p>
+     * Calling this method when the controller is already stopped has no effect.
+     */
+    public synchronized void stop() {
+        if (timerTask != null) {
+            timerTask = null;
+        }
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
+    }
+
+    /**
+     * Returns whether the controller has an active timer task.
+     *
+     * @return {@code true} if the watcher is scheduled, {@code false} otherwise
+     */
+    public synchronized boolean isRunning() {
+        return timerTask != null;
+    }
+
+    /**
+     * Stops the controller. Equivalent to {@link #stop()}.
+     */
+    @Override
+    public void close() {
+        stop();
+    }
+
+    /**
+     * Fluent builder for {@link WatcherTimerController}. Defaults are read from {@link WatcherConfig}
+     * when the builder is created, allowing the application to configure values before building.
+     */
+    public static final class Builder {
+        private String name = WatcherConfig.name;
+        private long delayMilliseconds = WatcherConfig.delayMilliseconds;
+        private long periodMilliseconds = WatcherConfig.periodMilliseconds;
+
+        private Builder() {
+            // Defaults are set above from WatcherConfig.
+        }
+
+        /**
+         * Sets the logical watcher name (and timer thread name).
+         *
+         * @param name logical watcher name
+         * @return this builder
+         */
+        public Builder name(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the initial delay before the first execution.
+         *
+         * @param delayMilliseconds delay in milliseconds
+         * @return this builder
+         */
+        public Builder delayMilliseconds(final long delayMilliseconds) {
+            this.delayMilliseconds = delayMilliseconds;
+            return this;
+        }
+
+        /**
+         * Sets the interval between executions.
+         *
+         * @param periodMilliseconds period in milliseconds
+         * @return this builder
+         */
+        public Builder periodMilliseconds(final long periodMilliseconds) {
+            this.periodMilliseconds = periodMilliseconds;
+            return this;
+        }
+
+        /**
+         * Builds a new controller. The owned {@link Watcher} is created from the configured name.
+         *
+         * @return a new controller
+         */
+        public WatcherTimerController build() {
+            return new WatcherTimerController(this);
+        }
+    }
+}

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherTimerController.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherTimerController.java
@@ -22,13 +22,13 @@ import java.util.TimerTask;
  * Periodically executes a {@link Watcher} using a {@link Timer}.
  * <p>
  * Each controller owns its own {@link Watcher} instance, created from the configured {@code name}.
- * By default, the controller reads {@code name}, {@code delayMilliseconds} and {@code periodMilliseconds}
- * from {@link WatcherConfig} at the moment the builder or {@code create()} method is invoked. This allows
- * the application to set configuration before materializing the watcher.
+ * By default, the factory methods read {@code name}, {@code delayMilliseconds} and {@code periodMilliseconds}
+ * from {@link WatcherConfig} at the moment they are called. This allows the application to set
+ * configuration before materializing the controller.
  * <p>
- * The controller exposes {@link #create()} shortcuts for the most common use cases, and a fluent
- * {@link Builder} for full flexibility. The underlying {@link Timer} is created as a daemon and named
- * after the watcher, so it will not prevent the JVM from shutting down.
+ * The controller exposes {@link #create()} static factory methods for common use cases. The underlying
+ * {@link Timer} is created as a daemon and named after the watcher, so it will not prevent the JVM from
+ * shutting down.
  * <p>
  * {@code start()} and {@code stop()} are idempotent and may be called multiple times.
  *
@@ -47,20 +47,18 @@ public final class WatcherTimerController implements AutoCloseable {
     private Timer timer;
     private TimerTask timerTask;
 
-    private WatcherTimerController(final Builder builder) {
-        this.name = builder.name;
-        this.delayMilliseconds = builder.delayMilliseconds;
-        this.periodMilliseconds = builder.periodMilliseconds;
-        this.watcher = new Watcher(name);
-    }
-
     /**
-     * Returns a builder pre-populated with defaults from {@link WatcherConfig}.
+     * Creates a new controller with the supplied configuration and builds the owned {@link Watcher}.
      *
-     * @return a new builder
+     * @param name                logical watcher name
+     * @param delayMilliseconds   initial delay before the first execution
+     * @param periodMilliseconds  interval between executions
      */
-    public static Builder builder() {
-        return new Builder();
+    private WatcherTimerController(final String name, final long delayMilliseconds, final long periodMilliseconds) {
+        this.name = name;
+        this.delayMilliseconds = delayMilliseconds;
+        this.periodMilliseconds = periodMilliseconds;
+        this.watcher = new Watcher(name);
     }
 
     /**
@@ -69,7 +67,7 @@ public final class WatcherTimerController implements AutoCloseable {
      * @return a new, not-yet-started controller
      */
     public static WatcherTimerController create() {
-        return builder().build();
+        return new WatcherTimerController(WatcherConfig.name, WatcherConfig.delayMilliseconds, WatcherConfig.periodMilliseconds);
     }
 
     /**
@@ -79,7 +77,7 @@ public final class WatcherTimerController implements AutoCloseable {
      * @return a new, not-yet-started controller
      */
     public static WatcherTimerController create(final String name) {
-        return builder().name(name).build();
+        return new WatcherTimerController(name, WatcherConfig.delayMilliseconds, WatcherConfig.periodMilliseconds);
     }
 
     /**
@@ -91,7 +89,7 @@ public final class WatcherTimerController implements AutoCloseable {
      * @return a new, not-yet-started controller
      */
     public static WatcherTimerController create(final String name, final long delayMilliseconds, final long periodMilliseconds) {
-        return builder().name(name).delayMilliseconds(delayMilliseconds).periodMilliseconds(periodMilliseconds).build();
+        return new WatcherTimerController(name, delayMilliseconds, periodMilliseconds);
     }
 
     /**
@@ -144,61 +142,5 @@ public final class WatcherTimerController implements AutoCloseable {
     @Override
     public void close() {
         stop();
-    }
-
-    /**
-     * Fluent builder for {@link WatcherTimerController}. Defaults are read from {@link WatcherConfig}
-     * when the builder is created, allowing the application to configure values before building.
-     */
-    public static final class Builder {
-        private String name = WatcherConfig.name;
-        private long delayMilliseconds = WatcherConfig.delayMilliseconds;
-        private long periodMilliseconds = WatcherConfig.periodMilliseconds;
-
-        private Builder() {
-            // Defaults are set above from WatcherConfig.
-        }
-
-        /**
-         * Sets the logical watcher name (and timer thread name).
-         *
-         * @param name logical watcher name
-         * @return this builder
-         */
-        public Builder name(final String name) {
-            this.name = name;
-            return this;
-        }
-
-        /**
-         * Sets the initial delay before the first execution.
-         *
-         * @param delayMilliseconds delay in milliseconds
-         * @return this builder
-         */
-        public Builder delayMilliseconds(final long delayMilliseconds) {
-            this.delayMilliseconds = delayMilliseconds;
-            return this;
-        }
-
-        /**
-         * Sets the interval between executions.
-         *
-         * @param periodMilliseconds period in milliseconds
-         * @return this builder
-         */
-        public Builder periodMilliseconds(final long periodMilliseconds) {
-            this.periodMilliseconds = periodMilliseconds;
-            return this;
-        }
-
-        /**
-         * Builds a new controller. The owned {@link Watcher} is created from the configured name.
-         *
-         * @return a new controller
-         */
-        public WatcherTimerController build() {
-            return new WatcherTimerController(this);
-        }
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/watcher/WatcherExecutorControllerTest.java
+++ b/src/test/java/org/usefultoys/slf4j/watcher/WatcherExecutorControllerTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.usefultoys.slf4j.watcher;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.impl.MockLogger;
+import org.slf4j.impl.MockLoggerEvent;
+import org.usefultoys.slf4jtestmock.AssertLogger;
+import org.usefultoys.slf4jtestmock.Slf4jMock;
+import org.usefultoys.slf4jtestmock.WithMockLogger;
+import org.usefultoys.test.ResetWatcherConfig;
+import org.usefultoys.test.ValidateCharset;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link WatcherExecutorController}.
+ * <p>
+ * Tests validate that the controller correctly starts and stops scheduled watchers
+ * using a {@link java.util.concurrent.ScheduledExecutorService}, with proper event logging
+ * and idempotent lifecycle operations.
+ */
+@ValidateCharset
+@ResetWatcherConfig
+@WithMockLogger
+class WatcherExecutorControllerTest {
+
+    @Slf4jMock("watcher")
+    private MockLogger logger;
+
+    @AfterEach
+    void stopController() {
+        // No global state to clean; each test owns its controller instance.
+    }
+
+    @Test
+    @DisplayName("should create controller with defaults from WatcherConfig")
+    void shouldCreateControllerWithDefaults() {
+        // When: creating with the no-arg shortcut
+        final WatcherExecutorController controller = WatcherExecutorController.create();
+
+        // Then: it is not running and can be started/stopped
+        assertNotNull(controller, "controller should be created");
+        assertFalse(controller.isRunning(), "controller should not be running initially");
+        assertDoesNotThrow(controller::start, "should start without throwing");
+        assertTrue(controller.isRunning(), "controller should be running after start");
+        assertDoesNotThrow(controller::stop, "should stop without throwing");
+        assertFalse(controller.isRunning(), "controller should not be running after stop");
+    }
+
+    @Test
+    @DisplayName("should create controller with custom name and schedule")
+    void shouldCreateControllerWithOverrides() {
+        // Given: a custom name and a logger bound to that name
+        final String customName = "custom-watcher";
+        final MockLogger customLogger = (MockLogger) LoggerFactory.getLogger(customName);
+        customLogger.clearEvents();
+
+        // When: creating with explicit name, delay and period
+        final WatcherExecutorController controller =
+                WatcherExecutorController.create(customName, 200, 200);
+
+        // Then: it runs the watcher under the requested name
+        assertNotNull(controller);
+        controller.start();
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> customLogger.getEventCount() > 0);
+        AssertLogger.assertEventCount(customLogger, 1);
+        AssertLogger.assertEvent(customLogger, 0, MockLoggerEvent.Level.INFO, "Memory:");
+        controller.stop();
+    }
+
+    @Test
+    @DisplayName("should log status when using executor")
+    void shouldLogStatusWithExecutor() {
+        // Given: short schedule
+        WatcherConfig.delayMilliseconds = 200;
+        WatcherConfig.periodMilliseconds = 200;
+
+        // When: creating and starting the controller
+        final WatcherExecutorController controller = WatcherExecutorController.create();
+        assertDoesNotThrow(controller::start, "should start without throwing");
+
+        // Then: a log event is generated
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> logger.getEventCount() > 0);
+        AssertLogger.assertEventCount(logger, 1);
+        AssertLogger.assertEvent(logger, 0, MockLoggerEvent.Level.INFO, "Memory:");
+
+        // When: stopping
+        assertDoesNotThrow(controller::stop, "should stop without throwing");
+        assertFalse(controller.isRunning(), "controller should not be running after stop");
+    }
+
+    @Test
+    @DisplayName("should support calling start multiple times")
+    void shouldSupportCallingStartMultipleTimes() {
+        // Given: a fresh controller
+        final WatcherExecutorController controller = WatcherExecutorController.create();
+
+        // When: starting twice
+        assertDoesNotThrow(controller::start, "first start should not throw");
+        assertDoesNotThrow(controller::start, "second start should not throw");
+
+        // Then: it remains running
+        assertTrue(controller.isRunning(), "controller should be running");
+
+        controller.stop();
+    }
+
+    @Test
+    @DisplayName("should support calling stop multiple times")
+    void shouldSupportCallingStopMultipleTimes() {
+        // Given: a started controller
+        final WatcherExecutorController controller = WatcherExecutorController.create();
+        controller.start();
+        assertTrue(controller.isRunning());
+
+        // When: stopping twice
+        assertDoesNotThrow(controller::stop, "first stop should not throw");
+        assertDoesNotThrow(controller::stop, "second stop should not throw");
+
+        // Then: it is not running
+        assertFalse(controller.isRunning(), "controller should not be running");
+    }
+
+    @Test
+    @DisplayName("should stop and clear resources")
+    void shouldStopAndClearResources() {
+        // Given: a started controller
+        final WatcherExecutorController controller = WatcherExecutorController.create();
+        controller.start();
+        assertTrue(controller.isRunning());
+
+        // When: stopped
+        controller.stop();
+
+        // Then: it reports as not running and can be restarted
+        assertFalse(controller.isRunning(), "controller should not be running after stop");
+        controller.start();
+        assertTrue(controller.isRunning(), "controller should be running after restart");
+        controller.stop();
+    }
+
+    @Test
+    @DisplayName("should close via try-with-resources")
+    void shouldCloseViaTryWithResources() {
+        // Given: a controller started inside a try-with-resources block
+        try (WatcherExecutorController controller = WatcherExecutorController.create()) {
+            controller.start();
+            assertTrue(controller.isRunning(), "controller should be running inside block");
+        }
+
+        // When/Then: after the block the controller is stopped
+        // (cannot query isRunning() because the resource is out of scope, but no exception means success)
+    }
+}

--- a/src/test/java/org/usefultoys/slf4j/watcher/WatcherSingletonTest.java
+++ b/src/test/java/org/usefultoys/slf4j/watcher/WatcherSingletonTest.java
@@ -16,8 +16,6 @@
 
 package org.usefultoys.slf4j.watcher;
 
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.impl.MockLogger;
@@ -28,149 +26,47 @@ import org.usefultoys.slf4jtestmock.WithMockLogger;
 import org.usefultoys.test.ResetWatcherConfig;
 import org.usefultoys.test.ValidateCharset;
 
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Unit tests for {@link WatcherSingleton}.
  * <p>
- * Tests validate that WatcherSingleton correctly starts and stops scheduled watchers
- * using both ExecutorService and Timer approaches, with proper event logging.
- * <p>
- * <b>Coverage:</b>
- * <ul>
- *   <li><b>Executor-based Watchers:</b> Tests starting and stopping watchers using ScheduledExecutorService</li>
- *   <li><b>Timer-based Watchers:</b> Tests starting and stopping watchers using Timer</li>
- *   <li><b>Status Logging:</b> Verifies correct logging of system status during watcher execution</li>
- *   <li><b>Watcher Management:</b> Ensures proper cleanup and singleton behavior</li>
- * </ul>
+ * Since push execution has been migrated to {@link WatcherExecutorController} and
+ * {@link WatcherTimerController}, this class now only verifies the lazy default {@link Watcher}
+ * instance used by the servlet pull path.
  */
 @ValidateCharset
 @ResetWatcherConfig
 @WithMockLogger
 class WatcherSingletonTest {
-    /* Needs to use same logger name was default name in WatcherConfig. */
+
     @Slf4jMock("watcher")
     private MockLogger logger;
 
-    @AfterEach
-    void stopAllWatchers() {
-        // Clean up scheduled tasks after each test
-        WatcherSingleton.stopDefaultWatcherExecutor();
-        WatcherSingleton.stopDefaultWatcherTimer();
+    @Test
+    @DisplayName("should return the same default watcher instance")
+    void shouldReturnSameDefaultWatcherInstance() {
+        // When: the default watcher is requested twice
+        final Watcher first = WatcherSingleton.getDefaultWatcher();
+        final Watcher second = WatcherSingleton.getDefaultWatcher();
+
+        // Then: both references point to the same lazily-created instance
+        assertNotNull(first, "default watcher should be created on first access");
+        assertSame(first, second, "default watcher should be a singleton");
     }
 
     @Test
-    @DisplayName("should log status when using executor")
-    void shouldLogStatusWithExecutor() {
-        // Given: watcher configuration set with specific delays and name
-        WatcherConfig.delayMilliseconds = 200;
-        WatcherConfig.periodMilliseconds = 200;
+    @DisplayName("should run the default watcher using the configured name")
+    void shouldRunDefaultWatcherUsingConfiguredName() {
+        // Given: the default watcher created from WatcherConfig.name ("watcher")
+        final Watcher watcher = WatcherSingleton.getDefaultWatcher();
 
-        // When: executor is not yet started
-        // Then: executor and watcher should be null
-        assertNull(WatcherSingleton.defaultWatcherExecutor, "defaultWatcherExecutor should be null before start");
-        assertNull(WatcherSingleton.scheduledDefaultWatcher, "scheduledDefaultWatcher should be null before start");
+        // When: the watcher is executed
+        watcher.run();
 
-        // When: starting the default watcher executor
-        assertDoesNotThrow(WatcherSingleton::startDefaultWatcherExecutor, "should start executor without throwing");
-
-        // Then: executor and watcher should be initialized
-        assertNotNull(WatcherSingleton.defaultWatcherExecutor, "defaultWatcherExecutor should be initialized");
-        assertNotNull(WatcherSingleton.scheduledDefaultWatcher, "scheduledDefaultWatcher should be initialized");
-
-        final ScheduledExecutorService executor = WatcherSingleton.defaultWatcherExecutor;
-        final ScheduledFuture<?> watcher = WatcherSingleton.scheduledDefaultWatcher;
-
-        // When: starting the executor multiple times
-        assertDoesNotThrow(WatcherSingleton::startDefaultWatcherExecutor, "should support calling start multiple times");
-
-        // Then: same executor and watcher instances should be reused
-        assertEquals(executor, WatcherSingleton.defaultWatcherExecutor, "should reuse same executor instance");
-        assertEquals(watcher, WatcherSingleton.scheduledDefaultWatcher, "should reuse same watcher instance");
-
-        // When: waiting for log messages to be generated by scheduled task
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() ->
-                logger.getEventCount() > 0
-        );
-
-        // Then: one log event should be recorded
+        // Then: it logs to the logger named after WatcherConfig.name
         AssertLogger.assertEventCount(logger, 1);
         AssertLogger.assertEvent(logger, 0, MockLoggerEvent.Level.INFO, "Memory:");
-
-        // When: stopping the executor
-        assertDoesNotThrow(WatcherSingleton::stopDefaultWatcherExecutor, "should stop executor without throwing");
-
-        // Then: executor and watcher should be cleared
-        assertNull(WatcherSingleton.defaultWatcherExecutor, "defaultWatcherExecutor should be null after stop");
-        assertNull(WatcherSingleton.scheduledDefaultWatcher, "scheduledDefaultWatcher should be null after stop");
-
-        // When: stopping the executor multiple times
-        assertDoesNotThrow(WatcherSingleton::stopDefaultWatcherExecutor, "should support calling stop multiple times");
-
-        // Then: should remain null
-        assertNull(WatcherSingleton.defaultWatcherExecutor, "defaultWatcherExecutor should remain null");
-        assertNull(WatcherSingleton.scheduledDefaultWatcher, "scheduledDefaultWatcher should remain null");
-    }
-
-    @Test
-    @DisplayName("should log status when using timer")
-    void shouldLogStatusWithTimer() {
-        // Given: watcher configuration set with specific delays and name
-        WatcherConfig.delayMilliseconds = 200;
-        WatcherConfig.periodMilliseconds = 200;
-
-        // When: timer is not yet started
-        // Then: timer and task should be null
-        assertNull(WatcherSingleton.defaultWatcherTimer, "defaultWatcherTimer should be null before start");
-        assertNull(WatcherSingleton.defaultWatcherTask, "defaultWatcherTask should be null before start");
-
-        // When: starting the default watcher timer
-        assertDoesNotThrow(WatcherSingleton::startDefaultWatcherTimer, "should start timer without throwing");
-
-        // Then: timer and task should be initialized
-        assertNotNull(WatcherSingleton.defaultWatcherTimer, "defaultWatcherTimer should be initialized");
-        assertNotNull(WatcherSingleton.defaultWatcherTask, "defaultWatcherTask should be initialized");
-
-        final Timer timer = WatcherSingleton.defaultWatcherTimer;
-        final TimerTask timerTask = WatcherSingleton.defaultWatcherTask;
-
-        // When: starting the timer multiple times
-        assertDoesNotThrow(WatcherSingleton::startDefaultWatcherTimer, "should support calling start multiple times");
-
-        // Then: same timer and task instances should be reused
-        assertEquals(timer, WatcherSingleton.defaultWatcherTimer, "should reuse same timer instance");
-        assertEquals(timerTask, WatcherSingleton.defaultWatcherTask, "should reuse same task instance");
-
-        // When: waiting for log messages to be generated by scheduled task
-        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() ->
-                logger.getEventCount() > 0
-        );
-
-        // Then: one log event should be recorded
-        AssertLogger.assertEventCount(logger, 1);
-        AssertLogger.assertEvent(logger, 0, MockLoggerEvent.Level.INFO, "Memory:");
-
-        // When: stopping the timer
-        assertDoesNotThrow(WatcherSingleton::stopDefaultWatcherTimer, "should stop timer without throwing");
-
-        // Then: timer and task should be cleared
-        assertNull(WatcherSingleton.defaultWatcherTimer, "defaultWatcherTimer should be null after stop");
-        assertNull(WatcherSingleton.defaultWatcherTask, "defaultWatcherTask should be null after stop");
-
-        // When: stopping the timer multiple times
-        assertDoesNotThrow(WatcherSingleton::stopDefaultWatcherTimer, "should support calling stop multiple times");
-
-        // Then: should remain null
-        assertNull(WatcherSingleton.defaultWatcherTimer, "defaultWatcherTimer should remain null");
-        assertNull(WatcherSingleton.defaultWatcherTask, "defaultWatcherTask should remain null");
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/watcher/WatcherTimerControllerTest.java
+++ b/src/test/java/org/usefultoys/slf4j/watcher/WatcherTimerControllerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.usefultoys.slf4j.watcher;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.impl.MockLogger;
+import org.slf4j.impl.MockLoggerEvent;
+import org.usefultoys.slf4jtestmock.AssertLogger;
+import org.usefultoys.slf4jtestmock.Slf4jMock;
+import org.usefultoys.slf4jtestmock.WithMockLogger;
+import org.usefultoys.test.ResetWatcherConfig;
+import org.usefultoys.test.ValidateCharset;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link WatcherTimerController}.
+ * <p>
+ * Tests validate that the controller correctly starts and stops scheduled watchers
+ * using a {@link java.util.Timer}, with proper event logging and idempotent lifecycle operations.
+ */
+@ValidateCharset
+@ResetWatcherConfig
+@WithMockLogger
+class WatcherTimerControllerTest {
+
+    @Slf4jMock("watcher")
+    private MockLogger logger;
+
+    @AfterEach
+    void stopController() {
+        // No global state to clean; each test owns its controller instance.
+    }
+
+    @Test
+    @DisplayName("should create controller with defaults from WatcherConfig")
+    void shouldCreateControllerWithDefaults() {
+        // When: creating with the no-arg shortcut
+        final WatcherTimerController controller = WatcherTimerController.create();
+
+        // Then: it is not running and can be started/stopped
+        assertNotNull(controller, "controller should be created");
+        assertFalse(controller.isRunning(), "controller should not be running initially");
+        assertDoesNotThrow(controller::start, "should start without throwing");
+        assertTrue(controller.isRunning(), "controller should be running after start");
+        assertDoesNotThrow(controller::stop, "should stop without throwing");
+        assertFalse(controller.isRunning(), "controller should not be running after stop");
+    }
+
+    @Test
+    @DisplayName("should create controller with custom name and schedule")
+    void shouldCreateControllerWithOverrides() {
+        // Given: a custom name and a logger bound to that name
+        final String customName = "custom-watcher";
+        final MockLogger customLogger = (MockLogger) LoggerFactory.getLogger(customName);
+        customLogger.clearEvents();
+
+        // When: creating with explicit name, delay and period
+        final WatcherTimerController controller =
+                WatcherTimerController.create(customName, 200, 200);
+
+        // Then: it runs the watcher under the requested name
+        assertNotNull(controller);
+        controller.start();
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> customLogger.getEventCount() > 0);
+        AssertLogger.assertEventCount(customLogger, 1);
+        AssertLogger.assertEvent(customLogger, 0, MockLoggerEvent.Level.INFO, "Memory:");
+        controller.stop();
+    }
+
+    @Test
+    @DisplayName("should log status when using timer")
+    void shouldLogStatusWithTimer() {
+        // Given: short schedule
+        WatcherConfig.delayMilliseconds = 200;
+        WatcherConfig.periodMilliseconds = 200;
+
+        // When: creating and starting the controller
+        final WatcherTimerController controller = WatcherTimerController.create();
+        assertDoesNotThrow(controller::start, "should start without throwing");
+
+        // Then: a log event is generated
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> logger.getEventCount() > 0);
+        AssertLogger.assertEventCount(logger, 1);
+        AssertLogger.assertEvent(logger, 0, MockLoggerEvent.Level.INFO, "Memory:");
+
+        // When: stopping
+        assertDoesNotThrow(controller::stop, "should stop without throwing");
+        assertFalse(controller.isRunning(), "controller should not be running after stop");
+    }
+
+    @Test
+    @DisplayName("should support calling start multiple times")
+    void shouldSupportCallingStartMultipleTimes() {
+        // Given: a fresh controller
+        final WatcherTimerController controller = WatcherTimerController.create();
+
+        // When: starting twice
+        assertDoesNotThrow(controller::start, "first start should not throw");
+        assertDoesNotThrow(controller::start, "second start should not throw");
+
+        // Then: it remains running
+        assertTrue(controller.isRunning(), "controller should be running");
+
+        controller.stop();
+    }
+
+    @Test
+    @DisplayName("should support calling stop multiple times")
+    void shouldSupportCallingStopMultipleTimes() {
+        // Given: a started controller
+        final WatcherTimerController controller = WatcherTimerController.create();
+        controller.start();
+        assertTrue(controller.isRunning());
+
+        // When: stopping twice
+        assertDoesNotThrow(controller::stop, "first stop should not throw");
+        assertDoesNotThrow(controller::stop, "second stop should not throw");
+
+        // Then: it is not running
+        assertFalse(controller.isRunning(), "controller should not be running");
+    }
+
+    @Test
+    @DisplayName("should stop and clear resources")
+    void shouldStopAndClearResources() {
+        // Given: a started controller
+        final WatcherTimerController controller = WatcherTimerController.create();
+        controller.start();
+        assertTrue(controller.isRunning());
+
+        // When: stopped
+        controller.stop();
+
+        // Then: it reports as not running and can be restarted
+        assertFalse(controller.isRunning(), "controller should not be running after stop");
+        controller.start();
+        assertTrue(controller.isRunning(), "controller should be running after restart");
+        controller.stop();
+    }
+
+    @Test
+    @DisplayName("should close via try-with-resources")
+    void shouldCloseViaTryWithResources() {
+        // Given: a controller started inside a try-with-resources block
+        try (WatcherTimerController controller = WatcherTimerController.create()) {
+            controller.start();
+            assertTrue(controller.isRunning(), "controller should be running inside block");
+        }
+
+        // When/Then: after the block the controller is stopped
+        // (cannot query isRunning() because the resource is out of scope, but no exception means success)
+    }
+}


### PR DESCRIPTION
## Context

WatcherSingleton was introduced as a convenience wrapper for the default Watcher, exposing static startDefaultWatcherExecutor() / startDefaultWatcherTimer() methods for push execution. As documented in TDR-0012 and the local findings, this design created configuration rigidity, test-state leakage, lifecycle leaks and a race condition when the same Watcher instance was shared between schedulers and the servlet pull path.

## Problem

- The default Watcher was cached once, freezing WatcherConfig values at first access (.glm-findings/02).
- The executor, timer and servlet threads all invoked un() on the same Watcher instance without synchronization (.glm-findings/03).
- The legacy Timer was non-daemon, blocking JVM shutdown if not explicitly stopped (.glm-findings/05).
- The global static singleton created hidden dependencies and made tests hard to isolate.

## Solution

Replace the push side of WatcherSingleton with two first-class, instance-based controllers:

- WatcherExecutorController — schedules a dedicated Watcher via ScheduledExecutorService.
- WatcherTimerController — schedules a dedicated Watcher via Timer.

Each controller:
- Owns its own Watcher instance, created from the configured 
ame.
- Captures WatcherConfig defaults (
ame, delayMilliseconds, periodMilliseconds) when create() is invoked (late creation).
- Exposes static create(...) factory methods only.
- Implements AutoCloseable for safe lifecycle management.
- Uses a daemon thread named after the watcher.

WatcherSingleton is reduced to the minimum needed by the servlet pull path: only getDefaultWatcher() remains, marked @Deprecated.

## Code Changes

- **New** src/main/java/org/usefultoys/slf4j/watcher/WatcherExecutorController.java
- **New** src/main/java/org/usefultoys/slf4j/watcher/WatcherTimerController.java
- **Modified** src/main/java/org/usefultoys/slf4j/watcher/WatcherSingleton.java — removed push methods and fields; kept deprecated getDefaultWatcher().
- **New** src/test/java/org/usefultoys/slf4j/watcher/WatcherExecutorControllerTest.java
- **New** src/test/java/org/usefultoys/slf4j/watcher/WatcherTimerControllerTest.java
- **Modified** src/test/java/org/usefultoys/slf4j/watcher/WatcherSingletonTest.java — slimmed to the pull-path behavior.
- **Modified** README.md — added Watcher section with controller examples.
- **New** doc/TDR-0036-replace-watcher-singleton-push-with-controllers.md
- **Modified** doc/TDR-0012-watcher-singleton-regret.md — marked superseded for push, pull pending.
- **Modified** doc/TDR-0005-robust-and-minimalist-configuration-mechanism.md — updated static-init limitation note.
- **Modified** doc/TDR-0008-flexible-execution-strategies-push-vs-pull.md — push strategy now references the controllers.
- **Modified** plan/avoid-watcher-singleton.md — noted factory-method-only design.

## Test Results

- mvnw.cmd -B '-Pslf4j-2.0' test -> 3077 tests, 0 failures.
- mvnw.cmd -B '-Pslf4j-2.0,with-logback' test -> 3152 tests, 0 failures.
- mvnw.cmd -B '-Pslf4j-1.7-javax' test -> 3045 tests, 0 failures.

## Breaking Change

WatcherSingleton.startDefaultWatcherExecutor() and WatcherSingleton.startDefaultWatcherTimer() are removed. Callers must migrate to WatcherExecutorController.create().start() / WatcherTimerController.create().start().

---

*AI-generated PR description, reviewed and refined by the user.*