### PR TITLE
perf(meter): optimize human-readable message formatting (locale-free, allocation-free)

### DIFF
--- a/doc/TDR-0040-locale-independent-readable-messages.md
+++ b/doc/TDR-0040-locale-independent-readable-messages.md
@@ -1,0 +1,123 @@
+# TDR-0040: Locale-Independent Formatting for Human-Readable Messages
+
+**Status**: Accepted  
+**Date**: 2026-07-11
+
+## Context
+
+The human-readable log messages of `Meter` and `Watcher` (start/progress/stop lines and watcher
+snapshots) are built on the instrumentation hot path: every lifecycle event formats timing, throughput,
+iteration counts and memory sizes for humans. All of these funnel through `UnitFormatter`, the single
+formatting helper shared by `MeterDataFormatter`, `WatcherDataFormatter` and the `report` package.
+
+Profiling of the readable path showed two costs concentrated in `UnitFormatter`:
+
+- Decimal values were rendered with `String.format(SessionConfig.locale, "%.1f%s", ...)`. Each call parses
+  the format string, allocates a `Formatter`, autoboxes its arguments, and performs a locale lookup.
+- Every `UnitFormatter` method returned a `String` that the caller then copied into its `StringBuilder` —
+  an intermediate allocation per formatted value, on top of the `Formatter` cost.
+
+The sibling JSON5 serialization path already removed the equivalent `String.format` cost via scaled-integer
+arithmetic (see [TDR-0039](./TDR-0039-accept-scaled-integer-rounding-in-json5-serialization.md)), but that
+decision was scoped to the machine-readable JSON5 output, which is locale-independent by requirement. The
+readable path additionally consulted `SessionConfig.locale`, so the decimal separator (e.g. `','` under a
+German or Brazilian locale) was locale-dependent.
+
+## Decision
+
+Human-readable messages no longer use the locale. `UnitFormatter` stops consulting `SessionConfig.locale`
+and always formats decimals in an arbitrarily chosen US style: a fixed `'.'` decimal separator produced by
+scaled-integer arithmetic, extending the [TDR-0039](./TDR-0039-accept-scaled-integer-rounding-in-json5-serialization.md)
+strategy from JSON5 to the readable path.
+
+```java
+// Locale-independent, one decimal place, no Formatter. See TDR-0039 / TDR-0040.
+final long scaled = Math.round(value * 10);
+sb.append(scaled / 10).append('.').append(scaled % 10).append(unit);
+```
+
+We prioritize **speed and allocation** over **internationalization**. slf4j-toys is a
+diagnostic/instrumentation tool: a single, standard numeric format is sufficient for reading diagnostic
+output, and locale-specific number formatting carries no analytical value while costing a `Formatter`
+round-trip and a locale lookup on every instrumentation event.
+
+To also remove the intermediate `String`, `UnitFormatter` gains `append*(StringBuilder, ...)` variants
+(`appendBytes`, `appendNanoseconds`, `appendIterations`, `appendIterationsPerSecond`) that write directly
+into the caller's buffer. `MeterDataFormatter` and `WatcherDataFormatter` use these on the hot path. The
+existing `String`-returning methods (`bytes`, `nanoseconds`, ...) are kept, delegating to the append core,
+so the `report` package and unit tests are unaffected.
+
+The scaled-integer rounding may differ by one unit in the last decimal from `String.format("%.1f")` in rare
+tie cases, exactly as accepted in TDR-0039. In practice the intermediate `value * 10` multiplication rounds
+ties toward the representable half (e.g. `1.15 * 10` yields `11.5`), so the existing `UnitFormatterTest`
+expectations remain satisfied without modification.
+
+## Consequences
+
+### Positive ✅
+
+- **No `Formatter` overhead on the readable path**: no format-string parsing, no `Formatter` allocation, no
+  autoboxing, no locale lookup for decimal fields.
+- **No intermediate `String`**: the `append*` variants write straight into the message `StringBuilder`,
+  removing one allocation per formatted value on every Meter/Watcher event.
+- **Consistency with JSON5**: both output paths now share one rounding and separator strategy (scaled-integer,
+  `'.'`), making formatting behavior uniform and auditable across the codebase.
+- **Simplicity**: dropping locale removes the `DecimalFormatSymbols`/locale-caching machinery that a
+  locale-aware manual formatter would otherwise require.
+
+### Negative ❌
+
+- **No internationalization of readable numbers**: users under comma-decimal locales now see `1.2kB` instead
+  of `1,2kB`. Accepted deliberately: diagnostic output favors a single standard format over localization.
+- **Rounding is not exact `%.1f`**: values whose decimal expansion lies extremely close to a tie may format
+  one unit higher or lower in the last decimal. Accepted as diagnostic measurement noise (per TDR-0039).
+- **Fixed precision at the call site**: the scale factor `10` (one decimal) is hardcoded; changing precision
+  means revisiting the arithmetic rather than a format string.
+
+### Neutral ⚖️
+
+- `SessionConfig.locale` is no longer read by `UnitFormatter`. The configuration field itself is retained,
+  since other components may still consult it; pruning it is out of scope for this change.
+
+## Alternatives Considered
+
+### ❌ Keep `String.format(SessionConfig.locale, "%.1f%s", ...)`
+
+**Description**: Preserve locale-aware decimal formatting via `String.format` on the readable path only.
+
+**Why rejected**: Retains exactly the `Formatter` overhead (format-string parsing, allocation, autoboxing,
+locale lookup) and the intermediate `String` that this change set out to remove, for a value — localized
+decimal separators — that has no diagnostic significance.
+
+### ❌ Locale-aware manual formatting (cached decimal separator)
+
+**Description**: Reproduce the current localized output by fetching the decimal separator from
+`DecimalFormatSymbols.getInstance(SessionConfig.locale)`, caching it, and invalidating the cache when the
+runtime locale changes.
+
+**Why rejected**: Adds caching and invalidation complexity to preserve a distinction (comma vs. dot) that
+carries no analytical value for a diagnostic tool. Contradicts the minimalism the project favors.
+
+### ❌ Epsilon-calibrated rounding to match `%.1f` exactly
+
+**Description**: Add a small relative epsilon before `Math.round` to reproduce `String.format("%.1f")`
+tie-breaking on the shortest decimal expansion, keeping output byte-for-byte identical.
+
+**Why rejected**: This is the hand-written decimal-expansion complexity already rejected by TDR-0039, to
+preserve a last-digit distinction with no diagnostic meaning. The plain scaled-integer form already satisfies
+all existing tests.
+
+## Implementation
+
+- `src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java` — scaled-integer, locale-independent decimal
+  formatting in the append-based `longUnit`/`doubleUnit` engines; new `append*(StringBuilder, ...)` variants;
+  `String`-returning methods retained as delegating overloads; `SessionConfig` import removed.
+- `src/main/java/org/usefultoys/slf4j/meter/MeterDataFormatter.java` — call sites migrated to `UnitFormatter.append*`.
+- `src/main/java/org/usefultoys/slf4j/watcher/WatcherDataFormatter.java` — call sites migrated to `UnitFormatter.append*`.
+- `src/test/java/org/usefultoys/slf4j/utils/UnitFormatterTest.java` — existing expectations pass unchanged.
+
+## References
+
+- [TDR-0039: Accept Scaled-Integer Rounding in JSON5 Serialization](./TDR-0039-accept-scaled-integer-rounding-in-json5-serialization.md)
+- [TDR-0004: Minimalist Manual JSON Implementation](./TDR-0004-minimalist-manual-json-implementation.md)
+- [src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java](../src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java)

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterDataFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterDataFormatter.java
@@ -113,10 +113,10 @@ final class MeterDataFormatter {
         boolean hasPrevious = false;
         if (data.isStarted() && data.getCurrentIteration() > 0) {
             hasPrevious = separator(builder, hasPrevious);
-            builder.append(UnitFormatter.iterations(data.getCurrentIteration()));
+            UnitFormatter.appendIterations(builder, data.getCurrentIteration());
             if (data.getExpectedIterations() > 0) {
                 builder.append('/');
-                builder.append(UnitFormatter.iterations(data.getExpectedIterations()));
+                UnitFormatter.appendIterations(builder, data.getExpectedIterations());
             }
         }
 
@@ -124,23 +124,23 @@ final class MeterDataFormatter {
         if (!data.isStarted()) {
             /* For not-yet-started operations, show waiting time */
             hasPrevious = separator(builder, hasPrevious);
-            builder.append(UnitFormatter.nanoseconds(data.getWaitingTime()));
+            UnitFormatter.appendNanoseconds(builder, data.getWaitingTime());
         } else {
             /* Show execution time for stopped operations or when progress info is required */
             if (data.isStopped() || progressInfoRequired) {
                 hasPrevious = separator(builder, hasPrevious);
-                builder.append(UnitFormatter.nanoseconds(executionTime));
+                UnitFormatter.appendNanoseconds(builder, executionTime);
             }
 
             /* Show throughput metrics for operations with iterations */
             if (data.getCurrentIteration() > 0 && (data.isStopped() || progressInfoRequired)) {
                 hasPrevious = separator(builder, hasPrevious);
                 final double iterationsPerSecond = data.getIterationsPerSecond();
-                builder.append(UnitFormatter.iterationsPerSecond(iterationsPerSecond));
+                UnitFormatter.appendIterationsPerSecond(builder, iterationsPerSecond);
                 builder.append(' ');
                 /* Calculate inverse metric: time per iteration */
                 final double nanoSecondsPerIteration = 1.0F / iterationsPerSecond * 1000000000;
-                builder.append(UnitFormatter.nanoseconds(nanoSecondsPerIteration));
+                UnitFormatter.appendNanoseconds(builder, nanoSecondsPerIteration);
             }
         }
 
@@ -167,7 +167,7 @@ final class MeterDataFormatter {
         /* System Info */
         if (MeterConfig.printMemory && data.getRuntime_maxMemory() > 0) {
             hasPrevious = MeterDataFormatter.separator(builder, hasPrevious);
-            builder.append(UnitFormatter.bytes(data.getRuntime_usedMemory()));
+            UnitFormatter.appendBytes(builder, data.getRuntime_usedMemory());
         }
         if (MeterConfig.printLoad && data.getSystemLoad() > 0) {
             hasPrevious = MeterDataFormatter.separator(builder, hasPrevious);

--- a/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
@@ -66,7 +66,7 @@ public final class UnitFormatter {
         int index = 0;
         final int limit = factors[index] + factors[index] / 10;
         if (value < limit) {
-            return String.format(SessionConfig.locale, "%d%s", value, units[index]);
+            return Long.toString(value).concat(units[index]);
         }
 
         final int length = factors.length;

--- a/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
@@ -17,7 +17,6 @@ package org.usefultoys.slf4j.utils;
 
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-import org.usefultoys.slf4j.SessionConfig;
 
 /**
  * Utility class that provides methods to format numbers by rounding them to a unit,
@@ -29,6 +28,17 @@ import org.usefultoys.slf4j.SessionConfig;
  *
  * <p>Negative values, {@code NaN} and infinite values are not supported and are rendered as "?"
  * followed by the base unit (e.g., "?B", "?ns", "?/s").
+ *
+ * <p><b>Formatting is locale-independent by design.</b> Decimal values are rendered with scaled-integer
+ * arithmetic and a fixed {@code '.'} decimal separator (US style), never consulting the session locale.
+ * This favors speed and allocation on the instrumentation hot path over internationalization, which
+ * carries no analytical value for diagnostic output. See
+ * {@code doc/TDR-0040-locale-independent-readable-messages.md} and
+ * {@code doc/TDR-0039-accept-scaled-integer-rounding-in-json5-serialization.md}.
+ *
+ * <p>Callers on the hot path should prefer the {@code append*(StringBuilder, ...)} variants, which write
+ * directly into the caller's buffer and avoid the intermediate {@link String} that the {@link String}-returning
+ * methods allocate.
  *
  * @author Daniel Felix Ferber
  * @author Co-authored-by: GitHub Copilot using OpenCode Go / Kimi K2.7 Code
@@ -47,7 +57,7 @@ public final class UnitFormatter {
 
     /**
      * Formats a long integer value into a human-readable string with appropriate units.
-     * This method is used internally by the public formatting methods.
+     * This method is used internally by the public formatting methods and by unit tests.
      *
      * <p>Negative values are not supported and are rendered as "?" followed by the base unit.
      *
@@ -57,16 +67,36 @@ public final class UnitFormatter {
      * @return A formatted string representing the value with units, or "?" followed by the base unit
      *         when the value is negative.
      */
+    String longUnit(final long value, @NonNull final String[] units, @NonNull final int[] factors) {
+        final StringBuilder sb = new StringBuilder(12);
+        longUnit(sb, value, units, factors);
+        return sb.toString();
+    }
+
+    /**
+     * Appends a human-readable representation of a long integer value with appropriate units directly
+     * into the provided {@link StringBuilder}, avoiding the intermediate {@link String} allocation of
+     * {@link #longUnit(long, String[], int[])}.
+     *
+     * <p>Negative values are not supported and are rendered as "?" followed by the base unit.
+     *
+     * @param sb The StringBuilder that receives the formatted representation.
+     * @param value The long integer value to format.
+     * @param units An array of unit strings (e.g., "B", "kB", "MB").
+     * @param factors An array of factors for unit conversion (e.g., 1000, 1000, 1000).
+     */
     @SuppressWarnings("AssignmentToMethodParameter")
-    String longUnit(long value, @NonNull final String[] units, @NonNull final int[] factors) {
+    void longUnit(final StringBuilder sb, long value, @NonNull final String[] units, @NonNull final int[] factors) {
         if (value < 0) {
-            return "?" + units[0];
+            sb.append('?').append(units[0]);
+            return;
         }
 
         int index = 0;
         final int limit = factors[index] + factors[index] / 10;
         if (value < limit) {
-            return Long.toString(value).concat(units[index]);
+            sb.append(value).append(units[index]);
+            return;
         }
 
         final int length = factors.length;
@@ -77,7 +107,7 @@ public final class UnitFormatter {
             value /= factors[index];
             index++;
         }
-        return String.format(SessionConfig.locale, "%.1f%s", doubleValue, units[index]);
+        appendScaledDecimal(sb, doubleValue, units[index]);
     }
 
     /**
@@ -87,7 +117,7 @@ public final class UnitFormatter {
 
     /**
      * Formats a double-precision floating-point value into a human-readable string with appropriate units.
-     * This method is used internally by the public formatting methods.
+     * This method is used internally by the public formatting methods and by unit tests.
      *
      * <p>Negative values, {@code NaN} and infinite values are not supported and are rendered as "?"
      * followed by the base unit.
@@ -98,13 +128,34 @@ public final class UnitFormatter {
      * @return A formatted string representing the value with units, or "?" followed by the base unit
      *         when the value is negative, {@code NaN} or infinite.
      */
+    String doubleUnit(final double value, @NonNull final String[] units, @NonNull final int[] factors) {
+        final StringBuilder sb = new StringBuilder(12);
+        doubleUnit(sb, value, units, factors);
+        return sb.toString();
+    }
+
+    /**
+     * Appends a human-readable representation of a double-precision value with appropriate units directly
+     * into the provided {@link StringBuilder}, avoiding the intermediate {@link String} allocation of
+     * {@link #doubleUnit(double, String[], int[])}.
+     *
+     * <p>Negative values, {@code NaN} and infinite values are not supported and are rendered as "?"
+     * followed by the base unit.
+     *
+     * @param sb The StringBuilder that receives the formatted representation.
+     * @param value The double value to format.
+     * @param units An array of unit strings (e.g., "/s", "k/s", "M/s").
+     * @param factors An array of factors for unit conversion (e.g., 1000, 1000, 1000).
+     */
     @SuppressWarnings("AssignmentToMethodParameter")
-    String doubleUnit(double value, @NonNull final String[] units, @NonNull final int[] factors) {
+    void doubleUnit(final StringBuilder sb, double value, @NonNull final String[] units, @NonNull final int[] factors) {
         if (value == 0.0) {
-            return "0" + units[0];
+            sb.append('0').append(units[0]);
+            return;
         }
         if (value < 0.0 || Double.isNaN(value) || Double.isInfinite(value)) {
-            return "?" + units[0];
+            sb.append('?').append(units[0]);
+            return;
         }
 
         int index = 0;
@@ -114,7 +165,29 @@ public final class UnitFormatter {
             value /= factors[index];
             index++;
         }
-        return String.format(SessionConfig.locale, "%.1f%s", value, units[index]);
+        appendScaledDecimal(sb, value, units[index]);
+    }
+
+    /**
+     * Appends a non-negative value rounded to one decimal place, followed by its unit, using scaled-integer
+     * arithmetic and a fixed {@code '.'} decimal separator (locale-independent).
+     *
+     * <p>This replaces {@code String.format(locale, "%.1f%s", ...)} to remove the {@code Formatter} overhead
+     * (format-string parsing, allocation, autoboxing) from the hot path. As accepted in TDR-0039 and extended
+     * to human-readable messages by TDR-0040, the scaled-integer rounding may differ by one unit in the last
+     * decimal from {@code %.1f} in rare tie cases; this is accepted as diagnostic measurement noise.
+     *
+     * <p>No overflow guard is needed: {@link Math#round(double)} saturates at {@link Long#MAX_VALUE} for the
+     * extreme inputs reachable here (e.g. {@link Long#MAX_VALUE} bytes, {@link Double#MAX_VALUE} iterations/s),
+     * so this never throws.
+     *
+     * @param sb The StringBuilder that receives the formatted representation.
+     * @param value The non-negative value to render with one decimal place.
+     * @param unit The unit suffix to append.
+     */
+    private void appendScaledDecimal(final StringBuilder sb, final double value, final String unit) {
+        final long scaled = Math.round(value * 10);
+        sb.append(scaled / 10).append('.').append(scaled % 10).append(unit);
     }
 
     /**
@@ -128,6 +201,17 @@ public final class UnitFormatter {
     }
 
     /**
+     * Appends a human-readable byte size (B, kB, MB, GB) directly into the provided {@link StringBuilder},
+     * avoiding the intermediate {@link String} of {@link #bytes(long)}.
+     *
+     * @param sb The StringBuilder that receives the formatted value.
+     * @param value The number of bytes.
+     */
+    public void appendBytes(final StringBuilder sb, final long value) {
+        longUnit(sb, value, MEMORY_UNITS, MEMORY_FACTORS);
+    }
+
+    /**
      * Formats a duration in nanoseconds into a human-readable string with appropriate time units.
      *
      * @param value The duration in nanoseconds.
@@ -135,6 +219,17 @@ public final class UnitFormatter {
      */
     public String nanoseconds(final long value) {
         return longUnit(value, TIME_UNITS, TIME_FACTORS);
+    }
+
+    /**
+     * Appends a human-readable duration (ns, us, ms, s, m, h) directly into the provided {@link StringBuilder},
+     * avoiding the intermediate {@link String} of {@link #nanoseconds(long)}.
+     *
+     * @param sb The StringBuilder that receives the formatted value.
+     * @param value The duration in nanoseconds.
+     */
+    public void appendNanoseconds(final StringBuilder sb, final long value) {
+        longUnit(sb, value, TIME_UNITS, TIME_FACTORS);
     }
 
     /**
@@ -148,6 +243,17 @@ public final class UnitFormatter {
     }
 
     /**
+     * Appends a human-readable duration (ns, us, ms, s, m, h) directly into the provided {@link StringBuilder},
+     * avoiding the intermediate {@link String} of {@link #nanoseconds(double)}.
+     *
+     * @param sb The StringBuilder that receives the formatted value.
+     * @param value The duration in nanoseconds.
+     */
+    public void appendNanoseconds(final StringBuilder sb, final double value) {
+        doubleUnit(sb, value, TIME_UNITS, TIME_FACTORS);
+    }
+
+    /**
      * Formats a number of iterations into a human-readable string with appropriate units.
      *
      * @param value The number of iterations.
@@ -158,6 +264,17 @@ public final class UnitFormatter {
     }
 
     /**
+     * Appends a human-readable iteration count (plain, k, M, G) directly into the provided {@link StringBuilder},
+     * avoiding the intermediate {@link String} of {@link #iterations(long)}.
+     *
+     * @param sb The StringBuilder that receives the formatted value.
+     * @param value The number of iterations.
+     */
+    public void appendIterations(final StringBuilder sb, final long value) {
+        longUnit(sb, value, ITERATIONS_UNITS, ITERATIONS_FACTORS);
+    }
+
+    /**
      * Formats a number of iterations per second (as a double) into a human-readable string with appropriate units.
      *
      * @param value The number of iterations per second.
@@ -165,5 +282,16 @@ public final class UnitFormatter {
      */
     public String iterationsPerSecond(final double value) {
         return doubleUnit(value, ITERATIONS_PER_TIME_UNITS, ITERATIONS_PER_TIME_FACTORS);
+    }
+
+    /**
+     * Appends a human-readable throughput (/s, k/s, M/s, G/s) directly into the provided {@link StringBuilder},
+     * avoiding the intermediate {@link String} of {@link #iterationsPerSecond(double)}.
+     *
+     * @param sb The StringBuilder that receives the formatted value.
+     * @param value The number of iterations per second.
+     */
+    public void appendIterationsPerSecond(final StringBuilder sb, final double value) {
+        doubleUnit(sb, value, ITERATIONS_PER_TIME_UNITS, ITERATIONS_PER_TIME_FACTORS);
     }
 }

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherDataFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherDataFormatter.java
@@ -36,11 +36,11 @@ class WatcherDataFormatter {
         boolean hasPrevious = false;
         if (data.getRuntime_usedMemory() > 0 || data.getRuntime_maxMemory() > 0 || data.getRuntime_totalMemory() > 0) {
             builder.append("Memory: ");
-            builder.append(UnitFormatter.bytes(data.getRuntime_usedMemory()));
+            UnitFormatter.appendBytes(builder, data.getRuntime_usedMemory());
             builder.append(" ");
-            builder.append(UnitFormatter.bytes(data.getRuntime_totalMemory()));
+            UnitFormatter.appendBytes(builder, data.getRuntime_totalMemory());
             builder.append(" ");
-            builder.append(UnitFormatter.bytes(data.getRuntime_maxMemory()));
+            UnitFormatter.appendBytes(builder, data.getRuntime_maxMemory());
             hasPrevious = true;
         }
         if (data.getSystemLoad() > 0) {


### PR DESCRIPTION
## What

Optimizes the **human-readable** log messages of `Meter` and `Watcher` (start/progress/stop
lines and Watcher snapshots), mirroring the JSON5 serialization work already on `main`. All
readable formatting funnels through `UnitFormatter`, which had two costs on the instrumentation
hot path:

1. Decimals were rendered with `String.format(locale, "%.1f%s", ...)` — format-string parsing,
   `Formatter` allocation, autoboxing, and a locale lookup on every event.
2. Every `UnitFormatter` method returned a `String` that the caller copied into its
   `StringBuilder` — one intermediate allocation per formatted value.

This change removes both:

- **No `Formatter`, no locale**: decimals are formatted with locale-independent scaled-integer
  arithmetic (`Math.round(v*10)`, fixed `'.'` separator), extending the TDR-0039 strategy from
  the JSON5 path to the readable path. Documented in **TDR-0040**.
- **No intermediate `String`**: new `append*(StringBuilder, ...)` variants write straight into
  the caller's buffer. `MeterDataFormatter` and `WatcherDataFormatter` use these on the hot path.
  The `String`-returning methods are retained (delegating), so the `report` package and unit
  tests are untouched.

## Why locale is dropped

slf4j-toys is a diagnostic/instrumentation tool. A single standard numeric format is sufficient
for reading diagnostic output; localized decimal separators carry no analytical value while
costing a `Formatter` round-trip and a locale lookup on every event. We deliberately prioritize
**speed and allocation** over **internationalization**. See TDR-0040 for the full rationale and
rejected alternatives.

## Benchmark results

Measured with the JMH `benchmarks/` module, `-prof gc`, metric `gc.alloc.rate.norm` (bytes/op),
3 forks. Results reported for the **MESSAGE** regime (readable logger on, data logger off), which
isolates the readable path — the data/JSON5 path is not exercised there, so this regime measures
exactly this change.

| Benchmark (MESSAGE)                       | alloc B/op        | Δ        |
|-------------------------------------------|-------------------|----------|
| `construct` / `create` (control, no format) | 360 / 616 → same | 0%       |
| `startOk` / `startReject` / `startFail` (load 0–50) | ~1640 → 1344 | **−18%** |
| same, load 500–5000                        | ~2020 → 1352      | **−33%** |
| `okWithMessage` / `okWithPath` / `startClose` / `createStartOk` | ~1690 → 1380 | **−17…−18%** |
| `okWithContext`                           | 2187 → 1680       | **−23%** |
| `okWithIterations`                        | 3973 → 1392       | **−65%** |
| `run` (Watcher snapshot)                  | 2550 → 419        | **−84%** |
| **Total (sum of per-benchmark averages)** | 43243 → 31100     | **−28%** |

Wall time (ns/op) drops in step (~15% on the terminal ops). The gain scales with the number of
formatted fields: `okWithIterations` and the Watcher snapshot (three `bytes` fields) benefit most.
The `construct`/`create` controls are unchanged, confirming the effect is isolated to the
formatting path.

### GC load

The primary GC signal is `gc.alloc.rate.norm` (bytes allocated **per operation**), which is
load-independent and directly reflects this change: **−28%** aggregate (table above). The
allocation throughput `gc.alloc.rate` corroborates at **−10%** (683.7 → 614.4 MB/s), and the
heaviest allocator, the Watcher `run` snapshot, drops from **249 → 137 collections**
(`gc.count`) and **136 → 85 ms** (`gc.time`).

The raw aggregate `gc.count` (−7%) and `gc.time` (+17%) are reported by JMH over a fixed
wall-clock window, so they are confounded by throughput (the faster `after` executes more ops
per window) and dominated by benchmarks this change does not touch (`create` and the CPU-load
simulation in `startX`, whose per-op allocation is unchanged). The +17% `gc.time` is
GC-scheduling/heap noise concentrated in those out-of-scope benchmarks, not a regression — the
per-operation metric, which is immune to that noise, is unambiguous.

> Note: the `MESSAGE_DATA` regime is intentionally not reported. Its baseline was captured before
> the JSON5 optimization landed on `main`, so that regime would conflate two unrelated changes.
> The MESSAGE regime is unaffected by JSON5 and gives a clean measurement of this branch.

## Tests

Existing `UnitFormatterTest` (189 cases) passes unchanged — the `value*10` multiplication rounds
ties toward the representable half, so the pinned boundary outputs remain satisfied. Core and
`with-logback` suites green.

## References

- TDR-0040: Locale-Independent Formatting for Human-Readable Messages
- TDR-0039: Accept Scaled-Integer Rounding in JSON5 Serialization
