### PR TITLE
Make Meter identifier formatting locale-independent

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/meter/MeterData.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterData.java
@@ -251,7 +251,7 @@ public class MeterData extends SystemData implements MeterAnalysis {
         if (operation == null) {
             return category + '#' + getPosition();
         }
-        return String.format("%s/%s#%d", category, operation, getPosition());
+        return category + '/' + operation + '#' + getPosition();
     }
 
     /**


### PR DESCRIPTION
## Context

`MeterData.getFullID()` builds a meter's unique identifier (`category/operation#position`). It sits on the happy path: every sub-meter creation (`Meter.java:240`) and the validation/leak-detection error logging (`MeterValidator.java`) calls it.

## Problem

`getFullID()` built its identifier via `String.format`, which parses the format string and drives a `Formatter` on every call — and, being a `String.format` on the library's own data, it was the **last locale-dependent operation remaining in the Meter subsystem** (the readable-message and JSON5 paths were already made locale-free by the preceding perf work):

```java
// operation != null branch:
return String.format("%s/%s#%d", category, operation, getPosition());  // Formatter overhead + locale-sensitive %d ❌
```

TDR-0035 flags this as the largest avoidable cost on the happy path. The `operation == null` branch already used plain concatenation, so the two branches were also inconsistent.

## Solution

Replace the `String.format` call with plain string concatenation, which javac lowers to an `invokedynamic` `StringConcatFactory` call — far cheaper, less allocation, and **locale-independent**:

```java
return category + '/' + operation + '#' + getPosition();
```

The output is **byte-for-byte identical**: `%d` on the `long` position emits no grouping separators and no locale-specific digits, exactly what `Long.toString` (used by concatenation) produces. Both branches of `getFullID()` now use concatenation consistently.

## API Changes

None. `getFullID()`'s signature and output string are unchanged. **Backward compatible** — internal implementation only.

## Code Changes

**Production (1 file):**
- `MeterData.java` — `getFullID()`: `String.format(...)` → string concatenation.

**Tests:** none added — existing coverage (`MeterDataTest`, `MeterFactory` path/position tests) already asserts the identifier format.

## Test Results

Full suite, both tiers (`mvnw test -P slf4j-2.0,with-logback`), observed on this branch after rebasing onto latest `main`:

- Core tier: **3100** tests — 0 failures, 0 errors
- With-Logback tier: **75** tests — 0 failures, 0 errors
- **BUILD SUCCESS**

## Examples

```java
Meter m = MeterFactory.getMeter("db").sub("query");
m.getFullID();   // "db/query#1"  — identical before and after, in any default Locale
```

## Relevant Documentation

- TDR-0035 — identifies `getFullID()` `String.format` as the largest avoidable happy-path cost.
- Part of the ongoing Meter locale-independence / performance series (cf. TDR-0039, TDR-0040 and the preceding `perf(meter)` commits on `main`).

---

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
