### PR TITLE
Skip redundant logger decoration in Meter constructor when prefix/suffix are empty

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -152,8 +152,19 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 extractNextPosition(logger.getName(), operation),
                 logger.getName(), operation, parent);
         createTime = collectCurrentTime();
-        messageLogger = org.slf4j.LoggerFactory.getLogger(MeterConfig.messagePrefix + logger.getName() + MeterConfig.messageSuffix);
-        dataLogger = org.slf4j.LoggerFactory.getLogger(MeterConfig.dataPrefix + logger.getName() + MeterConfig.dataSuffix);
+        messageLogger = resolveDecoratedLogger(logger, MeterConfig.messagePrefix, MeterConfig.messageSuffix);
+        dataLogger = resolveDecoratedLogger(logger, MeterConfig.dataPrefix, MeterConfig.dataSuffix);
+    }
+
+    /**
+     * Resolves the logger to use for decorated (prefixed/suffixed) output. Reuses {@code base} directly when both
+     * {@code prefix} and {@code suffix} are empty (the default), avoiding a redundant name concatenation and
+     * backend logger-registry lookup for the common case.
+     */
+    private static Logger resolveDecoratedLogger(final Logger base, final String prefix, final String suffix) {
+        return (prefix.isEmpty() && suffix.isEmpty())
+                ? base
+                : org.slf4j.LoggerFactory.getLogger(prefix + base.getName() + suffix);
     }
 
     /**

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -146,6 +146,10 @@ public class MeterConfig {
      * for encoded data.
      * <p>
      * Value is read from system property {@code slf4jtoys.meter.data.prefix}, defaulting to an empty string.
+     * <p>
+     * Setting a non-empty prefix or suffix (see also {@link #dataSuffix}) adds a small initialization cost to
+     * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
+     * the category logger as-is.
      */
     public String dataPrefix;
 
@@ -159,6 +163,10 @@ public class MeterConfig {
      * for encoded data.
      * <p>
      * Value is read from system property {@code slf4jtoys.meter.data.suffix}, defaulting to an empty string.
+     * <p>
+     * Setting a non-empty prefix (see also {@link #dataPrefix}) or suffix adds a small initialization cost to
+     * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
+     * the category logger as-is.
      */
     public String dataSuffix;
 
@@ -172,6 +180,10 @@ public class MeterConfig {
      * for readable messages.
      * <p>
      * Value is read from system property {@code slf4jtoys.meter.message.prefix}, defaulting to an empty string.
+     * <p>
+     * Setting a non-empty prefix or suffix (see also {@link #messageSuffix}) adds a small initialization cost to
+     * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
+     * the category logger as-is.
      */
     public String messagePrefix;
 
@@ -185,6 +197,10 @@ public class MeterConfig {
      * for readable messages.
      * <p>
      * Value is read from system property {@code slf4jtoys.meter.message.suffix}, defaulting to an empty string.
+     * <p>
+     * Setting a non-empty prefix (see also {@link #messagePrefix}) or suffix adds a small initialization cost to
+     * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
+     * the category logger as-is.
      */
     public String messageSuffix;
 


### PR DESCRIPTION
Fixes #87

## Context

`Meter`'s constructor derives `messageLogger` and `dataLogger` from `MeterConfig`'s
configurable prefix/suffix settings (`messagePrefix`/`messageSuffix`/`dataPrefix`/`dataSuffix`).
This runs on every `Meter` construction, which is the hottest path in the library.

## Problem

The constructor always concatenates the prefix/suffix and calls `LoggerFactory.getLogger(...)`,
even under the default configuration where all four values are empty strings:

```java
messageLogger = org.slf4j.LoggerFactory.getLogger(MeterConfig.messagePrefix + logger.getName() + MeterConfig.messageSuffix);
dataLogger = org.slf4j.LoggerFactory.getLogger(MeterConfig.dataPrefix + logger.getName() + MeterConfig.dataSuffix);
```

With the default configuration, the resulting name is identical to `logger.getName()` ❌ — the
lookup just re-resolves the same `Logger` already passed in as a parameter. Every `new Meter(...)`
pays for two string concatenations and two backend logger-registry lookups for no benefit.

## Solution

Extract a `resolveDecoratedLogger(base, prefix, suffix)` helper that reuses `base` directly when
both `prefix` and `suffix` are empty, and only falls back to the concatenation + `LoggerFactory.getLogger()`
lookup otherwise. The check is re-evaluated on every construction, so `MeterConfig`'s runtime-mutable
prefix/suffix fields are still honored — no caching, no new data structures.

Also added a note to `MeterConfig`'s `dataPrefix`/`dataSuffix`/`messagePrefix`/`messageSuffix` Javadoc
stating that a non-empty value carries this per-`Meter` initialization cost.

## API Changes

None — `resolveDecoratedLogger` is a private static method. Behavior is unchanged: when prefix/suffix
are non-empty, the result is byte-for-byte identical to before. When empty (default), `messageLogger`/
`dataLogger` become the same object as the passed-in `logger`, which already had the same *name* as
the old lookup result, so no observable logging behavior changes.

## Code Changes

- `src/main/java/org/usefultoys/slf4j/meter/Meter.java`: extract `resolveDecoratedLogger`, use it for
  both `messageLogger` and `dataLogger` (+13/-2 lines)
- `src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java`: document the initialization cost on the
  four prefix/suffix fields (+16 lines, Javadoc only)
- No test changes — existing `MeterConstructorTest` (16 tests) already asserts on logger *names*, not
  identity, covering both the default and prefix/suffix-configured cases.

## Test Results

- Core tier (`.\mvnw test`): 3116 tests, 0 failures
- Full suite (`.\mvnw test -P slf4j-2.0,with-logback`): 3116 + 75 = 3191 tests, 0 failures

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
