### PR TITLE
Avoid discarded AtomicLong allocation in Meter.extractNextPosition

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -193,11 +193,13 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      */
     static long extractNextPosition(final String eventCategory, final String operationName) {
         final String key = operationName == null ? eventCategory : eventCategory + "/" + operationName;
-        EVENT_COUNTER.putIfAbsent(key, new AtomicLong(0));
-        final AtomicLong atomicLong = EVENT_COUNTER.get(key);
+        AtomicLong counter = EVENT_COUNTER.get(key);
+        if (counter == null) {
+            counter = EVENT_COUNTER.computeIfAbsent(key, k -> new AtomicLong());
+        }
         /* Reset counter when it reaches maximum value to prevent overflow */
-        atomicLong.compareAndSet(Long.MAX_VALUE, 0);
-        return atomicLong.incrementAndGet();
+        counter.compareAndSet(Long.MAX_VALUE, 0);
+        return counter.incrementAndGet();
     }
 
     /**


### PR DESCRIPTION
Fixes #88

## Context

`Meter.extractNextPosition` is a static helper called from every `Meter` constructor to obtain the next sequential position for a `(category[/operation])` key, backed by the JVM-wide `EVENT_COUNTER` map (see TDR-0023).

## Problem

`extractNextPosition` allocated a discarded `AtomicLong` and performed two map lookups on every call, even in the common steady-state case where the counter for that key already exists:

```java
EVENT_COUNTER.putIfAbsent(key, new AtomicLong(0));  // argument evaluated eagerly — always allocates ❌
final AtomicLong atomicLong = EVENT_COUNTER.get(key); // second lookup
```

`putIfAbsent(key, new AtomicLong(0))` evaluates its second argument before the call, so a new `AtomicLong` was allocated on every single `Meter` construction — garbage on arrival whenever the key already existed, which is the common case for repeatedly-constructed operations. The map was also walked twice (`putIfAbsent` then `get`) where one lookup suffices.

## Solution

Use a fast-path `get()`, falling back to `computeIfAbsent()` only when the key is genuinely new:

```java
AtomicLong counter = EVENT_COUNTER.get(key);
if (counter == null) {
    counter = EVENT_COUNTER.computeIfAbsent(key, k -> new AtomicLong());
}
```

`computeIfAbsent` still guarantees only one `AtomicLong` is published per key under concurrent first-use, so the thread-safety and monotonic-per-key guarantees documented in TDR-0023 are unchanged. The key format, the `EVENT_COUNTER` field (name/type/visibility), and the overflow-wrap guard (`compareAndSet(Long.MAX_VALUE, 0)`) are all untouched — required because existing tests seed `Meter.EVENT_COUNTER` directly via `.put(key, new AtomicLong(...))` to make position assertions deterministic.

In steady state (key already present), this eliminates the allocation entirely and reduces two map operations to one.

## Code Changes

- `src/main/java/org/usefultoys/slf4j/meter/Meter.java` — `extractNextPosition` rewritten to fast-path `get()` + `computeIfAbsent()` fallback (production code only, no test changes needed).

## Test Results

- `MeterBasicFeaturesTest`, `MeterFactoryTest`, `MeterConstructorTest` (92 tests, includes the `PositionExtractionTests` covering sequential increments, per-key independence, and overflow wraparound): all pass, unchanged.
- Full suite, both tiers (`.\mvnw test -P slf4j-2.0,with-logback`): 3116 + 75 tests, 0 failures, 0 errors.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
