### PR TITLE
Skip discarded metric collection and message formatting in Meter.commonOk()

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -561,24 +561,33 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             }
 
             if (messageLogger.isWarnEnabled()) { // Check warn enabled to cover info as well
-                SystemMetrics.getInstance().collectRuntimeStatus(this);
-                SystemMetrics.getInstance().collectPlatformStatus(this);
-
                 final boolean warnSlowness = isSlow();
-                final String message1 = readableMessage();
-                /* Log at WARN level for slow operations, INFO level otherwise */
-                if (warnSlowness) {
-                    messageLogger.warn(Markers.MSG_SLOW_OK, message1);
-                } else if (messageLogger.isInfoEnabled()) {
-                    messageLogger.info(Markers.MSG_OK, message1);
-                }
-                if (dataLogger.isTraceEnabled()) {
-                    final String message2 = json5Message();
-                    /* Use different marker for slow operations */
-                    if (warnSlowness) {
-                        dataLogger.trace(Markers.DATA_SLOW_OK, message2);
-                    } else {
-                        dataLogger.trace(Markers.DATA_OK, message2);
+                /* Whether the human-readable message will actually be emitted (WARN for slow, INFO otherwise) */
+                final boolean willLog = warnSlowness || messageLogger.isInfoEnabled();
+                final boolean willTrace = dataLogger.isTraceEnabled();
+
+                /* Skip metric collection and message formatting entirely when neither branch below will consume them */
+                if (willLog || willTrace) {
+                    SystemMetrics.getInstance().collectRuntimeStatus(this);
+                    SystemMetrics.getInstance().collectPlatformStatus(this);
+
+                    if (willLog) {
+                        final String message1 = readableMessage();
+                        /* Log at WARN level for slow operations, INFO level otherwise */
+                        if (warnSlowness) {
+                            messageLogger.warn(Markers.MSG_SLOW_OK, message1);
+                        } else {
+                            messageLogger.info(Markers.MSG_OK, message1);
+                        }
+                    }
+                    if (willTrace) {
+                        final String message2 = json5Message();
+                        /* Use different marker for slow operations */
+                        if (warnSlowness) {
+                            dataLogger.trace(Markers.DATA_SLOW_OK, message2);
+                        } else {
+                            dataLogger.trace(Markers.DATA_OK, message2);
+                        }
                     }
                 }
                 clearContext();

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterCommonOkGateTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterCommonOkGateTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.slf4j.impl.MockLogger;
+import org.usefultoys.slf4j.LoggerFactory;
+import org.usefultoys.slf4j.internal.SystemMetrics;
+import org.usefultoys.slf4j.internal.SystemMetricsCollector;
+import org.usefultoys.test.ValidateCleanMeter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.slf4j.impl.MockLoggerEvent.Level.TRACE;
+import static org.usefultoys.slf4j.meter.Markers.DATA_OK;
+
+/**
+ * Regression coverage for PERF-007: {@code commonOk()} must not collect system metrics nor format the
+ * human-readable message when the result will never be logged (message logger at WARN, operation not slow).
+ * <p>
+ * These tests mock {@link SystemMetrics#getInstance()} so that the assertions can prove the expensive collection
+ * work was skipped, rather than only observing the already-correct absence of a log event (which the buggy code
+ * also produces, since only the internal work was wasted, not the final emission).
+ */
+@ValidateCleanMeter
+class MeterCommonOkGateTest {
+
+    private static final String CATEGORY = "commonOkGate";
+
+    private MockLogger warnOnlyLogger() {
+        final MockLogger logger = (MockLogger) LoggerFactory.getLogger(CATEGORY);
+        logger.clearEvents();
+        logger.setErrorEnabled(true);
+        logger.setWarnEnabled(true);
+        logger.setInfoEnabled(false);
+        logger.setDebugEnabled(false);
+        logger.setTraceEnabled(false);
+        return logger;
+    }
+
+    @Test
+    void warnEnabledInfoDisabledNotSlow_skipsCollectionAndMessage() {
+        final MockLogger logger = warnOnlyLogger();
+
+        try (MockedStatic<SystemMetrics> mockedSystemMetrics = Mockito.mockStatic(SystemMetrics.class)) {
+            final SystemMetricsCollector mockCollector = Mockito.mock(SystemMetricsCollector.class);
+            mockedSystemMetrics.when(SystemMetrics::getInstance).thenReturn(mockCollector);
+
+            new Meter(logger).start().ok();
+
+            verify(mockCollector, never()).collectRuntimeStatus(any());
+            verify(mockCollector, never()).collectPlatformStatus(any());
+        }
+        assertEquals(0, logger.getEventCount());
+    }
+
+    @Test
+    void warnEnabledInfoDisabledNotSlow_traceEnabled_stillCollectsForDataLogger() {
+        final MockLogger logger = warnOnlyLogger();
+        logger.setTraceEnabled(true);
+
+        try (MockedStatic<SystemMetrics> mockedSystemMetrics = Mockito.mockStatic(SystemMetrics.class)) {
+            final SystemMetricsCollector mockCollector = Mockito.mock(SystemMetricsCollector.class);
+            mockedSystemMetrics.when(SystemMetrics::getInstance).thenReturn(mockCollector);
+
+            new Meter(logger).start().ok();
+
+            verify(mockCollector).collectRuntimeStatus(any());
+            verify(mockCollector).collectPlatformStatus(any());
+        }
+        /* start() logs nothing (DEBUG disabled); only the data logger emits from commonOk() */
+        assertEquals(1, logger.getEventCount());
+        logger.assertEvent(0, TRACE, DATA_OK);
+    }
+
+    @Test
+    void warnEnabledInfoDisabledNotSlow_stillClearsContext() {
+        final MockLogger logger = warnOnlyLogger();
+
+        try (MockedStatic<SystemMetrics> mockedSystemMetrics = Mockito.mockStatic(SystemMetrics.class)) {
+            final SystemMetricsCollector mockCollector = Mockito.mock(SystemMetricsCollector.class);
+            mockedSystemMetrics.when(SystemMetrics::getInstance).thenReturn(mockCollector);
+
+            final Meter m = new Meter(logger).start().ctx("key", "value").ok();
+
+            assertTrue(m.getContext().isEmpty(), "context must still be cleared even though nothing was logged");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #90

## Context

`Meter.commonOk()` is the termination path for every successful operation (`ok()`/`success()`).
It logs a human-readable summary at WARN when the operation is slow, or at INFO otherwise, plus a
JSON5 data line at TRACE.

## Problem

The method's outer gate is `messageLogger.isWarnEnabled()`, but the message is only actually
emitted at WARN when the operation is slow, or at INFO otherwise:

```java
if (messageLogger.isWarnEnabled()) { // Check warn enabled to cover info as well
    SystemMetrics.getInstance().collectRuntimeStatus(this);
    SystemMetrics.getInstance().collectPlatformStatus(this);

    final boolean warnSlowness = isSlow();
    final String message1 = readableMessage();
    if (warnSlowness) {
        messageLogger.warn(Markers.MSG_SLOW_OK, message1);
    } else if (messageLogger.isInfoEnabled()) {
        messageLogger.info(Markers.MSG_OK, message1);      // message1 built above even when this is false ❌
    }
    ...
}
```

With a production root logger at WARN and a successful, non-slow operation (the common case),
`collectRuntimeStatus`/`collectPlatformStatus` (including a native `getSystemCpuLoad()` call) and
`readableMessage()` (StringBuilder + unit formatting) run on every call, and the result is
discarded unused. Every other termination path (`start()`, `progress()`, `reject()`, `fail()`)
already gates correctly on the level it actually logs at — `commonOk()` was the only one that
didn't, because of its conditional WARN/INFO level.

## Solution

**`Meter.commonOk()`** now computes `warnSlowness` and `willLog` (whether the WARN or INFO branch
will actually fire) before doing any collection, and only calls
`SystemMetrics.getInstance().collectRuntimeStatus()`/`collectPlatformStatus()` and
`readableMessage()` when `willLog` is true or the data logger's TRACE is enabled (needed for
`json5Message()`). The outer `isWarnEnabled()` gate and the position of `clearContext()` are
unchanged, so `clearContext()` still fires under exactly the same condition as before — no change
to context-clearing semantics, only to which expensive work runs inside the gate.

## Code Changes

- **Production**: `src/main/java/org/usefultoys/slf4j/meter/Meter.java` — restructured
  `commonOk()`'s WARN/INFO gate (26 insertions, 17 deletions).
- **Test**: `src/test/java/org/usefultoys/slf4j/meter/MeterCommonOkGateTest.java` (new, 3 tests) —
  mocks `SystemMetrics.getInstance()` statically to prove no collection happens in the
  WARN-enabled/INFO-disabled/non-slow scenario (a test that only checks for the absence of a log
  event would pass even on the buggy code, since the external behavior was already correct — only
  the internal work was wasted); confirms collection still happens when TRACE is enabled; confirms
  `clearContext()` still fires when nothing is logged.

## Test Results

- `.\mvnw test -Dtest=MeterCommonOkGateTest` — 3/3 pass.
- `.\mvnw test` (core tier) — 1441/1441 pass.
- `.\mvnw test -P slf4j-2.0,with-logback` (full tier) — 1525/1525 pass.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
