### PR TITLE
Avoid per-call unmodifiableMap allocation in MeterDataFormatter

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/meter/MeterDataFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterDataFormatter.java
@@ -151,7 +151,7 @@ final class MeterDataFormatter {
             builder.append(data.getDescription());
             builder.append('\'');
         }
-        final Map<String, String> context = data.getContext();
+        final Map<String, String> context = data.context;
         if (context != null && !context.isEmpty()) {
             /* Append all context entries as key=value or key-only for null values */
             for (final Map.Entry<String, String> entry : context.entrySet()) {


### PR DESCRIPTION
Fixes #94

## Context

`MeterDataFormatter.readableStringBuilder()` builds the human-readable log message for every meter event (start/progress/ok/reject/fail), including the operation's context entries.

## Problem

`MeterData.getContext()` defensively wraps the internal context map on every call:

```java
public Map<String, String> getContext() {
    return context == null ? Collections.emptyMap() : Collections.unmodifiableMap(context);
}
```

`MeterDataFormatter` calls this once per formatted message:

```java
final Map<String, String> context = data.getContext(); // allocates a new UnmodifiableMap ❌
```

Every logged event with a non-null context pays for a throwaway wrapper allocation the formatter doesn't need — it only iterates the map, never mutates it.

## Solution

`MeterDataFormatter` and `MeterData` live in the same package (`org.usefultoys.slf4j.meter`), so the formatter now reads the package-private **`context`** field directly instead of calling `getContext()`, removing the allocation entirely. `MeterData.getContext()` is unchanged and still used by external callers, where the defensive copy is correct.

## Code Changes

- `src/main/java/org/usefultoys/slf4j/meter/MeterDataFormatter.java` — 1 line changed (`data.getContext()` → `data.context`)
- No test changes — existing `MeterDataFormatterTest` coverage of context rendering (empty, single, multiple, null-value entries) already exercises this path.

## Test Results

`.\mvnw test -Dtest=MeterDataFormatterTest` — 222/222 tests pass.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
