### PR TITLE
Replace per-call unknown-meter allocation with a shared null-object

### DIFF
--- a/doc/TDR-0015-threadlocal-stack-for-context-propagation.md
+++ b/doc/TDR-0015-threadlocal-stack-for-context-propagation.md
@@ -51,3 +51,4 @@ We implemented a `ThreadLocal` stack of `Meter` instances to track the "current"
 ## References
 *   [TDR-0011: Null Object Pattern for Optional Logging](TDR-0011-null-object-pattern-for-optional-logging.md)
 *   [TDR-0017: Non-Intrusive Validation and Error Handling](TDR-0017-non-intrusive-validation-and-error-handling.md)
+*   [TDR-0042: Shared Null-Object for the Unknown Meter](TDR-0042-shared-null-object-for-unknown-meter.md) — refines the "dummy instance" mentioned above from a per-call allocation into a shared, immutable-by-rejection singleton.

--- a/doc/TDR-0042-shared-null-object-for-unknown-meter.md
+++ b/doc/TDR-0042-shared-null-object-for-unknown-meter.md
@@ -1,0 +1,102 @@
+# TDR-0042: Shared Null-Object for the Unknown Meter
+
+**Status**: Accepted
+**Date**: 2026-07-12
+
+## Context
+
+[TDR-0015](TDR-0015-threadlocal-stack-for-context-propagation.md) established that `Meter.getCurrentInstance()` must never return `null`: when no meter is active on the current thread, it returns a "dummy" `Meter` instead, following the Null Object Pattern already used elsewhere in the library ([TDR-0011](TDR-0011-null-object-pattern-for-optional-logging.md)). The original implementation allocated that dummy freshly on every miss:
+
+```java
+if (current == null) {
+    return new Meter(LoggerFactory.getLogger(UNKNOWN_LOGGER_NAME));
+}
+```
+
+This had two problems, both surfaced while reviewing the `Meter` construction/lifecycle hot path for GC pressure:
+
+1. **Allocation on a defensive read path.** Every call to `getCurrentInstance()` with no active meter pays the full `Meter` constructor: two derived-logger lookups with string concatenation, an `extractNextPosition("???", null)` call that increments the shared `EVENT_COUNTER` under the `"???"` key, and a creation timestamp. Code that defensively reads `getCurrentInstance()` on every request (to attach context if an operation happens to be running) pays this on every miss, and the ever-growing `"???"` position falsely suggests, in emitted data, that millions of `"???"` operations occurred.
+2. **The dummy is a *mutable* Null Object.** `Meter` is not immutable, and the returned dummy is a real, fully functional `Meter`. Calling `start()`, `m()`, `ctx()`, `ok()`, `reject()`, `fail()`, `close()`, `limitMilliseconds()`, or `iterations()` on it silently succeeds and mutates real state on a throwaway instance — none of the existing preconditions in `MeterValidator` reject these on a freshly constructed meter, because "never started" and "just constructed" are indistinguishable to them. This is harmless only because a *new* dummy is discarded after each call; it becomes a correctness hazard the moment allocation is removed and the dummy is shared.
+
+## Decision
+
+**`getCurrentInstance()` returns a single, process-wide shared instance of `UnknownMeter`, a private `Meter` subclass whose state-mutating methods are overridden to log an `INVALID_TRANSITION` and return `this` (or, for `void` methods, simply return) instead of mutating shared state.**
+
+```java
+private static final Meter UNKNOWN_INSTANCE = new UnknownMeter();
+
+public static Meter getCurrentInstance() {
+    final WeakReference<Meter> ref = localThreadInstance.get();
+    final Meter current = ref == null ? null : ref.get();
+    if (current == null) {
+        return UNKNOWN_INSTANCE;
+    }
+    return current;
+}
+```
+
+`UnknownMeter` overrides: `start()`, `commonOk(Object)` (covers `ok()`/`ok(Object)`/`success()`/`success(Object)` — they all funnel into it), `reject(Object)`, `fail(Object)`, `close()`, `putContext(String, Object)`/`putContext(String)` (covers `ctx(...)`/`unctx(...)` via `MeterContext`'s default methods), `m(String)`/`m(String, Object...)`, `limitMilliseconds(long)`, `iterations(long)`, and `sub(String)`. Each override calls a private `denied()` helper that logs the same `INVALID_TRANSITION` marker already used for other invalid-lifecycle calls (e.g. calling `start()` twice), then returns `this` unchanged.
+
+`inc()`, `incBy()`, `incTo()`, `progress()`, and `path(Object)` need **no** override: their existing preconditions (`validateIncPrecondition`, `validateProgressPrecondition`, `validatePathPrecondition`) already reject a meter with `startTime == 0`, and `UNKNOWN_INSTANCE` can never be started — `start()` is itself denied — so `startTime` stays `0` forever and these methods are already safe no-ops.
+
+**Overriding, not a flag.** The alternative of adding a boolean check (e.g. `if (meter.isUnknownMeter()) { ... }`) inside each `MeterValidator` precondition was rejected: that check would run on *every* call to *every* real `Meter`, adding a branch to the hot path in order to save an allocation on a cold miss path — backwards for a change motivated by performance. Overriding instead relies on the virtual dispatch the JVM already performs for these non-`final` instance methods; real `Meter` instances never reach `UnknownMeter` code and pay nothing extra, while `UNKNOWN_INSTANCE` alone carries the rejection logic.
+
+**`sub()` becomes absorbing, not delegating.** Previously, `getCurrentInstance().sub("child")` (the implementation of `MeterFactory.getCurrentSubMeter`) built a real, usable `"???/child"` meter even with no active parent — silently manufacturing a meaningless hierarchy entry. `UnknownMeter.sub(...)` now returns `UNKNOWN_INSTANCE` itself and logs the same `INVALID_TRANSITION`, i.e. `UNKNOWN_INSTANCE.sub(x) == UNKNOWN_INSTANCE`. Requesting a sub-operation with no active parent is exactly the same class of misuse as calling `ok()` with no active meter, and is now reported the same way.
+
+## Consequences
+
+### Positive ✅
+
+- **No more per-call allocation on the miss path.** `getCurrentInstance()` with no active meter now returns the same object every time, eliminating the constructor cost (logger lookups, concatenation, timestamp) and the `EVENT_COUNTER["???"]` inflation that misrepresented emitted data.
+- **Misuse becomes visible instead of silently mutating a throwaway object.** Calling a lifecycle method on "no active meter" now produces the same `INVALID_TRANSITION` diagnostic already used for other invalid transitions, consistent with the non-intrusive validation philosophy of [TDR-0017](TDR-0017-non-intrusive-validation-and-error-handling.md): the call never throws, but the misuse is no longer invisible.
+- **Zero hot-path cost for real meters.** The rejection logic lives entirely in `UnknownMeter`'s overrides; ordinary `Meter` instances and their call sites are unaffected and remain monomorphic.
+- **Safe to share across threads.** Because every mutating path is neutralized, the single static instance can be handed out to any number of threads concurrently with no synchronization and no data-race risk — unlike a plain shared `Meter`, which would have been a mutable object shared without coordination.
+
+### Negative ❌
+
+- **Behavioral change for the sub-meter fallback.** `MeterFactory.getCurrentSubMeter(name)` called with no active parent used to return a distinct, real `"???/name"` meter; it now returns the shared `UNKNOWN_INSTANCE` unchanged (category `"???"`, no operation). Call sites relying on the former fallback's identity or operation name observe different behavior. Verified against the full test suite (2839 tests, both `slf4j-2.0` and `slf4j-2.0,with-logback` profiles); one existing test (`MeterFactoryTest.shouldCreateSubMeterFromFallbackWhenNoCurrentMeterIsStarted`) was updated to assert the new absorbing behavior.
+- **Larger, harder-to-forget override surface.** Every future state-mutating method added to `Meter` must be remembered and added to `UnknownMeter`'s overrides, or it silently mutates the shared singleton again. This risk is bounded by the fact that all current mutators already follow the `if (!MeterValidator.validateXxx(this)) return this;` guard-clause pattern, making the override list mechanically derivable by inspection, and by `MeterUnknownInstanceTest`, which exercises every currently known mutator against the singleton.
+
+### Neutral ⚖️
+
+- **`UNKNOWN_INSTANCE`'s message/data loggers are fixed at class-load time.** Like other library statics, the loggers it reports through are derived from `MeterConfig.messagePrefix`/`messageSuffix` at construction, not re-read afterward — the same class of trade-off already accepted for `Meter`'s own logger fields.
+- **This does not change the single-thread lifecycle contract** ([TDR-0041](TDR-0041-single-thread-meter-lifecycle-contract.md)) or the `WeakReference`-based stack ([TDR-0015](TDR-0015-threadlocal-stack-for-context-propagation.md)); it only replaces what is handed out on a stack *miss*.
+
+## Alternatives Considered
+
+### ❌ Return `null` instead of a Null Object
+
+**Description**: Change `getCurrentInstance()` to return `null` when no meter is active, and let callers check.
+
+**Why rejected**: breaking change to a documented non-null contract. `MeterFactory.getCurrentMeter()`/`getCurrentSubMeter()` are annotated `@NonNull`, and `getCurrentSubMeter` calls `.sub(...)` directly on the result — a `null` return would turn every parent-less sub-meter request into an `NullPointerException`. Dozens of existing tests also assert on `getCurrentInstance().getCategory()` unconditionally.
+
+### ❌ Per-thread cached dummy (`ThreadLocal<Meter>`)
+
+**Description**: Keep allocating a real, mutable dummy, but cache one per thread via a second `ThreadLocal`, lazily created on first miss.
+
+**Why rejected**: reduces allocation from "per call" to "per thread" but does not address the mutability hazard — a shared-within-a-thread dummy is still silently mutable by `start()`/`ctx()`/etc., just with a smaller blast radius. It also adds a second `ThreadLocal` (with its own thread-pool retention profile) for a problem the shared-and-neutralized singleton solves more completely with less state.
+
+### ❌ Plain shared singleton, no overrides
+
+**Description**: Allocate `UNKNOWN_INSTANCE` once and return it from every miss, without changing `Meter`'s mutating methods.
+
+**Why rejected**: `Meter` is mutable and carries no internal synchronization ([TDR-0041](TDR-0041-single-thread-meter-lifecycle-contract.md) already documents that lifecycle fields assume single-thread ownership). A plain shared instance turns any stray `getCurrentInstance().ctx(...)`-style call from *any* thread into a cross-thread data race on shared state — an unacceptable trade for saving one allocation.
+
+### ❌ `isUnknownMeter()` flag with guards in `MeterValidator`
+
+**Description**: Add a boolean-returning identity check and branch on it at the top of each relevant `MeterValidator` precondition method.
+
+**Why rejected**: every one of those preconditions already runs on every call from every real `Meter` in the application. Adding a branch there to special-case a single shared instance imposes a permanent hot-path cost to solve a cold-path (miss-only) allocation problem — the opposite of the change's own motivation. Virtual dispatch via subclassing achieves the same rejection semantics at zero cost to real meters.
+
+## Implementation
+
+- [src/main/java/org/usefultoys/slf4j/meter/Meter.java](../src/main/java/org/usefultoys/slf4j/meter/Meter.java) — `UNKNOWN_INSTANCE` field, `getCurrentInstance()` miss path, and the nested `UnknownMeter` class with its overrides.
+- [src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java](../src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java) — asserts single-instance identity (repeated calls and across threads), the unknown category, and that every overridden mutator logs `INVALID_TRANSITION` without changing observable state.
+- [src/test/java/org/usefultoys/slf4j/meter/MeterFactoryTest.java](../src/test/java/org/usefultoys/slf4j/meter/MeterFactoryTest.java) — `shouldCreateSubMeterFromFallbackWhenNoCurrentMeterIsStarted` updated for the absorbing `sub()` behavior.
+
+## References
+
+- [TDR-0011: Null Object Pattern for Optional Logging](TDR-0011-null-object-pattern-for-optional-logging.md)
+- [TDR-0015: ThreadLocal Stack for Context Propagation](TDR-0015-threadlocal-stack-for-context-propagation.md)
+- [TDR-0017: Non-Intrusive Validation and Error Handling](TDR-0017-non-intrusive-validation-and-error-handling.md)
+- [TDR-0041: Single-Thread Meter Lifecycle Contract](TDR-0041-single-thread-meter-lifecycle-contract.md)

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -114,6 +114,15 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
     private WeakReference<Meter> previousInstance;
 
     /**
+     * Shared, process-wide null-object returned by {@link #getCurrentInstance()} when no meter is
+     * active on the current thread, replacing a fresh throwaway {@code Meter} allocated on every
+     * call. Every operation that would otherwise mutate a fresh {@code Meter} is overridden on
+     * {@link UnknownMeter} to log an {@code INVALID_TRANSITION} instead, so the shared instance is
+     * safe to read and safe to call from multiple threads at once. See TDR-0042.
+     */
+    private static final Meter UNKNOWN_INSTANCE = new UnknownMeter();
+
+    /**
      * Registration handle with the {@link MeterLeakDetector}, obtained on {@link #start()}.
      * {@code null} when the detector declines registration (disabled or unknown category). Passed back to
      * the detector on every explicit termination so this {@code Meter} is not reported as a leak.
@@ -216,15 +225,20 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
     /**
      * Returns the `Meter` instance most recently started on the current thread. This is useful for accessing the
      * current operation's context.
+     * <p>
+     * When no meter is active, this returns the shared {@link #UNKNOWN_INSTANCE} null-object rather than allocating
+     * a fresh one. Treat it as read-only: every mutating operation called on it (`start()`, `m()`, `ctx()`, `ok()`,
+     * `reject()`, `fail()`, `close()`, `limitMilliseconds()`, `iterations()`, `sub()`, ...) is a well-defined no-op
+     * that logs an {@code INVALID_TRANSITION} instead of silently mutating shared state. See TDR-0042.
      *
-     * @return The current `Meter` instance, or a dummy `Meter` if none is active on the current thread.
+     * @return The current `Meter` instance, or the shared unknown `Meter` if none is active on the current thread.
      */
     public static Meter getCurrentInstance() {
         final WeakReference<Meter> ref = localThreadInstance.get();
         final Meter current = ref == null ? null : ref.get();
-        /* Return dummy meter if no active meter on current thread */
+        /* Return the shared null-object if no active meter on current thread */
         if (current == null) {
-            return new Meter(LoggerFactory.getLogger(UNKNOWN_LOGGER_NAME));
+            return UNKNOWN_INSTANCE;
         }
         return current;
     }
@@ -810,6 +824,89 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             }
         } catch (final Exception t) {
             MeterValidator.logUnexpectedException(this, t);
+        }
+    }
+
+    /**
+     * Backing implementation of {@link #UNKNOWN_INSTANCE}: a {@code Meter} whose every
+     * state-mutating operation is overridden to log an {@code INVALID_TRANSITION} and return
+     * {@code this} (or, for {@code void} methods, simply return) instead of mutating shared state.
+     * This makes the single shared instance safe to hand out from {@link #getCurrentInstance()} to
+     * any number of threads at once. {@code inc()}, {@code incBy()}, {@code incTo()} and
+     * {@code progress()} need no override: their preconditions already reject a never-started
+     * meter, and this instance can never be started. See TDR-0042.
+     */
+    private static final class UnknownMeter extends Meter {
+
+        private static final long serialVersionUID = 1L;
+
+        UnknownMeter() {
+            super(LoggerFactory.getLogger(UNKNOWN_LOGGER_NAME));
+        }
+
+        private Meter denied() {
+            MeterValidator.logInvalidTransition(this, "no operation is active on the current thread");
+            return this;
+        }
+
+        @Override
+        public Meter start() {
+            return denied();
+        }
+
+        @Override
+        Meter commonOk(final Object pathId) {
+            return denied();
+        }
+
+        @Override
+        public Meter reject(final Object cause) {
+            return denied();
+        }
+
+        @Override
+        public Meter fail(final Object cause) {
+            return denied();
+        }
+
+        @Override
+        public void close() {
+            denied();
+        }
+
+        @Override
+        public void putContext(final String name, final Object value) {
+            denied();
+        }
+
+        @Override
+        public void putContext(final String name) {
+            denied();
+        }
+
+        @Override
+        public Meter m(final String message) {
+            return denied();
+        }
+
+        @Override
+        public Meter m(final String format, final Object... args) {
+            return denied();
+        }
+
+        @Override
+        public Meter limitMilliseconds(final long timeLimit) {
+            return denied();
+        }
+
+        @Override
+        public Meter iterations(final long expectedIterations) {
+            return denied();
+        }
+
+        @Override
+        public Meter sub(final String suboperationName) {
+            return denied();
         }
     }
 }

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterFactoryTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterFactoryTest.java
@@ -707,17 +707,20 @@ class MeterFactoryTest {
         }
 
         @Test
-        @DisplayName("should create sub meter from fallback when no current meter is started")
+        @DisplayName("should return the shared unknown meter, not a new sub meter, when no current meter is started")
         void shouldCreateSubMeterFromFallbackWhenNoCurrentMeterIsStarted() {
             // Given: no active meter on the current thread
+            final Meter unknown = Meter.getCurrentInstance();
 
             // When: a sub meter is requested
             final Meter sub = MeterFactory.getCurrentSubMeter("child");
 
-            // Then: a sub meter should be created from the fallback meter
-            assertNotNull(sub, "should create non-null sub meter even without current meter");
-            assertEquals(Meter.UNKNOWN_LOGGER_NAME, sub.getCategory(), "should inherit fallback category");
-            assertEquals("child", sub.getOperation(), "should use sub name as operation when parent has no operation");
+            // Then: sub() on the shared unknown meter is a no-op that returns itself (see TDR-0042),
+            // not a freshly allocated "???/child" meter
+            assertNotNull(sub, "should never return null even without current meter");
+            assertSame(unknown, sub, "should return the shared unknown meter itself, not allocate a sub meter");
+            assertEquals(Meter.UNKNOWN_LOGGER_NAME, sub.getCategory(), "should keep the unknown category");
+            assertNull(sub.getOperation(), "should not gain a 'child' operation from the rejected sub() call");
         }
 
         @Test

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.impl.MockLogger;
+import org.usefultoys.test.ResetMeterConfig;
+import org.usefultoys.test.ValidateCleanMeter;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.slf4j.impl.MockLoggerEvent.Level.ERROR;
+import static org.usefultoys.slf4j.meter.Markers.INVALID_TRANSITION;
+
+/**
+ * Verifies the shared, process-wide null-object returned by {@link Meter#getCurrentInstance()} when no meter is
+ * active on the current thread (see TDR-0042): it must never be allocated per call, must remain identical across
+ * threads, and every mutating operation called on it must be a well-defined no-op that logs an
+ * {@code INVALID_TRANSITION} instead of mutating shared state.
+ *
+ * @author Daniel Felix Ferber
+ */
+@ResetMeterConfig
+@ValidateCleanMeter
+@DisplayName("Meter.getCurrentInstance() shared unknown null-object")
+class MeterUnknownInstanceTest {
+
+    private MockLogger unknownLogger;
+
+    @BeforeEach
+    void resolveUnknownLogger() {
+        /* The unknown Meter is a static singleton; fetch the very logger it reports to, rather than
+           re-deriving the name from MeterConfig, which may have moved on since the singleton was built. */
+        unknownLogger = (MockLogger) Meter.getCurrentInstance().getMessageLogger();
+        unknownLogger.clearEvents();
+    }
+
+    @Test
+    @DisplayName("returns the same instance on repeated calls with no active meter")
+    void returnsSameInstanceOnRepeatedCalls() {
+        final Meter first = Meter.getCurrentInstance();
+        final Meter second = Meter.getCurrentInstance();
+        assertSame(first, second, "getCurrentInstance() must not allocate a new dummy per call");
+    }
+
+    @Test
+    @DisplayName("returns the same instance across threads")
+    void returnsSameInstanceAcrossThreads() throws InterruptedException {
+        final Meter mainThreadInstance = Meter.getCurrentInstance();
+        final AtomicReference<Meter> otherThreadInstance = new AtomicReference<>();
+        final Thread thread = new Thread(() -> otherThreadInstance.set(Meter.getCurrentInstance()));
+        thread.start();
+        thread.join();
+        assertSame(mainThreadInstance, otherThreadInstance.get(),
+                "the shared unknown instance must be the same object across threads");
+    }
+
+    @Test
+    @DisplayName("reports the unknown category")
+    void reportsUnknownCategory() {
+        assertEquals(Meter.UNKNOWN_LOGGER_NAME, Meter.getCurrentInstance().getCategory());
+    }
+
+    @Test
+    @DisplayName("start() logs an invalid transition and does not become the current instance")
+    void startLogsInvalidTransitionAndDoesNotBecomeCurrent() {
+        final Meter unknown = Meter.getCurrentInstance();
+
+        final Meter result = unknown.start();
+
+        assertSame(unknown, result, "start() on the unknown meter must be a no-op returning itself");
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+        assertSame(unknown, Meter.getCurrentInstance(),
+                "the unknown meter must not push itself onto the thread-local stack");
+    }
+
+    @Test
+    @DisplayName("m(String) logs an invalid transition")
+    void mWithMessageLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.m("should be ignored");
+        assertSame(unknown, result);
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("m(String, Object...) logs an invalid transition")
+    void mWithFormatLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.m("value=%d", 42);
+        assertSame(unknown, result);
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("ctx(String, Object) logs an invalid transition and does not store context")
+    void ctxLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        unknown.ctx("key", "value");
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("ok() logs an invalid transition and never records a stop time")
+    void okLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.ok();
+        assertSame(unknown, result);
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+        assertEquals(0, unknown.getStopTime(), "the unknown meter must never record a stop time");
+    }
+
+    @Test
+    @DisplayName("reject(Object) logs an invalid transition")
+    void rejectLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.reject("cause");
+        assertSame(unknown, result);
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("fail(Object) logs an invalid transition")
+    void failLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.fail("cause");
+        assertSame(unknown, result);
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("close() logs an invalid transition")
+    void closeLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        unknown.close();
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("limitMilliseconds(long) logs an invalid transition")
+    void limitMillisecondsLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.limitMilliseconds(100);
+        assertSame(unknown, result);
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("iterations(long) logs an invalid transition")
+    void iterationsLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.iterations(10);
+        assertSame(unknown, result);
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("sub(String) logs an invalid transition and returns itself, not a new sub-meter")
+    void subLogsInvalidTransitionAndReturnsSelf() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.sub("child");
+        assertSame(unknown, result, "sub() on the unknown meter must not allocate a new sub-meter");
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+}


### PR DESCRIPTION
## Context

`Meter.getCurrentInstance()` returns the meter most recently started on the current thread, or a stand-in "unknown" `Meter` (category `"???"`) when none is active — a Null Object so callers never need a null check. This stand-in is on a genuinely hot path: any code that defensively reads `getCurrentInstance()` to attach context if an operation happens to be running pays for it on every call where no meter is active.

## Problem

The miss path allocated a brand-new `Meter` on **every** call:

```java
public static Meter getCurrentInstance() {
    ...
    if (current == null) {
        return new Meter(LoggerFactory.getLogger(UNKNOWN_LOGGER_NAME)); // ❌ allocated every time
    }
    return current;
}
```

Each allocation pays the full constructor: two derived-logger lookups with string concatenation, an `extractNextPosition("???", null)` call that increments the shared `EVENT_COUNTER` under the `"???"` key, and a creation timestamp — pure overhead for a throwaway object, and the ever-growing `"???"` position falsely suggests, in emitted data, that millions of `"???"` operations occurred.

Worse, the returned dummy was a fully mutable `Meter`. Nothing stopped a caller from doing this and having it silently succeed:

```java
Meter.getCurrentInstance().start();     // "works" — mutates a throwaway instance ❌
Meter.getCurrentInstance().ctx("k", 1); // "works" — mutates a throwaway instance ❌
```

No existing `MeterValidator` precondition distinguishes "never started" from "just constructed", so these calls neither did anything meaningful nor told the caller they were wrong.

## Solution

`getCurrentInstance()` now returns a single, **shared, process-wide** instance (`UNKNOWN_INSTANCE`) instead of allocating a fresh one. Sharing a mutable object safely required also neutralizing it: `UNKNOWN_INSTANCE` is an instance of a new private `UnknownMeter extends Meter` subclass that overrides every state-mutating method (`start()`, `commonOk()` — covering `ok`/`ok(path)`/`success`/`success(path)` — `reject()`, `fail()`, `close()`, `putContext()` ×2 — covering `ctx()`/`unctx()` — `m()` ×2, `limitMilliseconds()`, `iterations()`, `sub()`) to log the existing `INVALID_TRANSITION` diagnostic and return `this` unchanged, rather than mutating shared state. `inc()`/`incBy()`/`incTo()`/`progress()`/`path()` needed no override — their existing preconditions already reject a never-started meter, and `UNKNOWN_INSTANCE` can never be started.

This is deliberately implemented via **subclass overrides**, not a boolean flag checked inside `MeterValidator`'s preconditions. A flag check would run on every call from every real `Meter` in the application to guard against a single shared instance — a permanent hot-path cost to solve a cold-path (miss-only) allocation problem. Virtual dispatch achieves the same rejection with zero cost to real meters.

One behavioral consequence follows directly: `sub()` becomes **absorbing** rather than delegating. `UNKNOWN_INSTANCE.sub(x) == UNKNOWN_INSTANCE` — requesting a sub-operation with no active parent is now treated as the same class of misuse as calling `ok()` with no active meter, instead of silently manufacturing a meaningless `"???/x"` hierarchy entry.

The design rationale and rejected alternatives (returning `null`, a per-thread cached dummy, an unguarded shared singleton, an `isUnknownMeter()` flag) are recorded in `doc/TDR-0042-shared-null-object-for-unknown-meter.md`.

## API Changes

### Modified Behavior

**`Meter.getCurrentInstance()`** (no signature change, still `@NonNull`):
- No longer allocates a new `Meter` per call when no meter is active; returns a shared singleton instead.
- The returned singleton rejects every mutating operation with an `INVALID_TRANSITION` log entry instead of silently mutating.

**`MeterFactory.getCurrentSubMeter(String)`** (no signature change):
- With no active parent meter, now returns the shared unknown instance itself (category `"???"`, no operation) instead of a freshly built `"???/<name>"` meter.

**Backward Compatibility**: Source- and binary-compatible — no signature changes. The only observable behavior change is the `sub()`-without-active-parent case described above; call sites relying on that fallback producing a distinct `"???/<name>"` meter (rather than the shared unknown instance) would see different results. This is the intended fix, treating that fallback as the same misuse class already reported for other lifecycle methods called with no active meter.

## Code Changes

**Production:**
- `src/main/java/org/usefultoys/slf4j/meter/Meter.java` — `UNKNOWN_INSTANCE` field, `getCurrentInstance()` miss path, and the new nested `UnknownMeter` class (12 overridden methods).

**Tests:**
- `src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java` (new, 14 tests) — single-instance identity across repeated calls and across threads, unknown category, and `INVALID_TRANSITION` logging with no observable state change for every overridden mutator.
- `src/test/java/org/usefultoys/slf4j/meter/MeterFactoryTest.java` (1 test updated) — `shouldCreateSubMeterFromFallbackWhenNoCurrentMeterIsStarted` now asserts the absorbing `sub()` behavior.

**Documentation:**
- `doc/TDR-0042-shared-null-object-for-unknown-meter.md` (new) — records the decision and rejected alternatives.
- `doc/TDR-0015-threadlocal-stack-for-context-propagation.md` — cross-references TDR-0042.

## Test Results

Full suite green on both profiles, run locally via the Maven wrapper:
- `.\mvnw test` (core, `slf4j-2.0`) — 2839 tests, 0 failures, 0 errors.
- `.\mvnw test -P slf4j-2.0,with-logback` — 2839 tests, 0 failures, 0 errors.

## Examples

```java
// Before: every miss allocates a new Meter, and it's silently mutable
Meter a = Meter.getCurrentInstance();
Meter b = Meter.getCurrentInstance();
a != b;               // true — two distinct throwaway allocations
a.start();             // "succeeds" silently, mutates the throwaway instance

// After: every miss returns the same shared, protected instance
Meter a = Meter.getCurrentInstance();
Meter b = Meter.getCurrentInstance();
a == b;                // true — no allocation
a.start();             // logs INVALID_TRANSITION, returns `a` unchanged
```

## Relevant Documentation

- [doc/TDR-0042-shared-null-object-for-unknown-meter.md](../blob/main/doc/TDR-0042-shared-null-object-for-unknown-meter.md)
- [doc/TDR-0015-threadlocal-stack-for-context-propagation.md](../blob/main/doc/TDR-0015-threadlocal-stack-for-context-propagation.md)
- [doc/TDR-0011-null-object-pattern-for-optional-logging.md](../blob/main/doc/TDR-0011-null-object-pattern-for-optional-logging.md)

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
