### PR TITLE
Make Meter/MeterContext message API use slf4j {} placeholders (breaking, major release)

### DIFF
--- a/doc/TDR-0042-slf4j-placeholders-as-primary-meter-message-api.md
+++ b/doc/TDR-0042-slf4j-placeholders-as-primary-meter-message-api.md
@@ -1,0 +1,154 @@
+# TDR-0042: slf4j `{}` Placeholders as the Primary Meter Message API
+
+**Status**: Accepted
+**Date**: 2026-07-12
+
+## Context
+
+`Meter.m(String, Object...)` and `MeterContext.ctx(String, String, Object...)` let application code
+attach a formatted, human-readable message to an operation or its context. Until this change, both
+overloads formatted their argument with `java.util.Formatter` (`String.format(format, args)`):
+
+- `MeterValidator.validateMCallArgument(meter, format, args)` (backing `Meter.m`)
+- `MeterContext.ctx(name, format, args)` (its own inline `String.format` call)
+
+This carried two costs, one already flagged by an independent Meter CPU/GC performance review
+(finding PERF-010, "eager `printf` formatting in `m(format, args)`"):
+
+- **`Formatter` overhead.** Every call parses the format string, allocates a `Formatter`, autoboxes its
+  arguments, and — unless a `Locale` is passed explicitly — performs a JVM-default-locale lookup. This
+  runs eagerly, even when the log line that would consume the message is disabled.
+- **A locale-dependent library surface.** [TDR-0039](TDR-0039-accept-scaled-integer-rounding-in-json5-serialization.md)
+  and [TDR-0040](TDR-0040-locale-independent-readable-messages.md) already removed locale dependence
+  from the JSON5 and readable-message paths (`UnitFormatter`, `MeterDataFormatter`,
+  `WatcherDataFormatter`). `m`/`ctx` were the last remaining locale-sensitive operations in the `Meter`
+  subsystem: `%f`/`%e`/`%g` conversions render with the JVM default locale's decimal separator unless the
+  caller remembers to pass one.
+
+A third, independent concern surfaced during review: **static analysis blind spot.** SAST/lint tools
+that flag malformed `printf`-style calls (Sonar `java:S2275`, IntelliJ's `MalformedFormatString`, Error
+Prone's `FormatString`) are wired to a fixed list of well-known methods (`String.format`, `printf`,
+`Formatter.format`, ...). A project-defined `Meter.m(String, Object...)` is invisible to them — a
+malformed `m("%d", "text")` call compiles, is not statically flagged, and is only caught at runtime by
+`MeterValidator`'s own defensive `try/catch`, which logs a warning instead of failing the build. For a
+diagnostics library, silently swallowing a caller's formatting mistake at runtime is a worse outcome
+than a build-time warning.
+
+slf4j itself defines an idiomatic, `Formatter`-free alternative: `{}`-placeholder substitution via
+`org.slf4j.helpers.MessageFormatter`, the same mechanism backing every `logger.info("... {}", arg)`
+call. It never throws (unmatched placeholders or excess arguments are left as-is / ignored), fitting the
+non-throwing philosophy of [TDR-0017](TDR-0017-non-intrusive-validation-and-error-handling.md).
+
+## Decision
+
+**`m`/`ctx` are redefined to use slf4j `{}` placeholders. The previous `printf` behavior is kept, renamed
+to `mf`/`ctxf`, and pinned to `Locale.ROOT`.** This is a deliberate, breaking API change, shipped in a
+major release:
+
+- **`Meter.m(String format, Object... args)`** — now substitutes `{}` placeholders via
+  `MessageFormatter.arrayFormat(format, args).getMessage()`. No `Formatter`, no locale lookup, no
+  exception path to guard (`MessageFormatter` never throws for a malformed pattern).
+- **`Meter.mf(String format, Object... args)`** (new name for the previous `m` overload) — keeps
+  `printf`-style formatting via `String.format(Locale.ROOT, format, args)`. The `Formatter` cost is
+  accepted deliberately for callers who need `printf` features (`%.2f`, width/padding) that `{}`
+  substitution cannot express; `Locale.ROOT` makes the one remaining locale-sensitive call
+  deterministic instead of environment-dependent.
+- **`MeterContext.ctx(String name, String format, Object... args)`** and
+  **`MeterContext.ctxf(String name, String format, Object... args)`** mirror the same split.
+- `mf`/`ctxf` still catch `IllegalFormatException` and log `INVALID_ARGUMENT` (the non-intrusive
+  contract from TDR-0017); `{}`-based `m`/`ctx` have no such catch because `MessageFormatter` has no
+  corresponding failure mode.
+
+Both `MessageFormatter.arrayFormat` (not the slf4j-2.0-only `basicArrayFormat`) is used specifically so
+the implementation works unmodified under both slf4j versions this project supports
+([TDR-0010](TDR-0010-simultaneous-support-for-slf4j-1.7-2.0-and-logback-1.2-1.5.md)). No new dependency
+is introduced — `slf4j-api` already provides `org.slf4j.helpers.MessageFormatter`.
+
+## Consequences
+
+### Positive ✅
+
+- **`Meter`/`MeterContext` no longer read the JVM default locale anywhere** on the primary `m`/`ctx`
+  path — this closes the last locale-dependent gap left after TDR-0039/TDR-0040, and even the `mf`/`ctxf`
+  fallback is now deterministic via `Locale.ROOT`.
+- **Cheaper default path.** `{}` substitution is a single linear scan with no format-string parsing, no
+  `Formatter`/`Matcher` allocation, and no locale lookup — strictly cheaper than the previous `printf`
+  default, addressing PERF-010 for the common case.
+- **Static-analysis visibility restored for callers who need `printf`.** A caller who genuinely needs
+  `%.2f`-style formatting now writes `mf(...)`, a name distinct enough that reviewers recognize it as
+  `printf`-flavored; callers who migrate their `String.format` call to the call site itself (rather than
+  inline it into `mf`) get full SAST/lint coverage, something the previous single `m` overload could
+  never offer.
+- **Consistent with the slf4j ecosystem.** Application code already writes `logger.info("... {} ...",
+  arg)` throughout; `meter.m("... {} ...", arg)` now follows the same convention instead of a
+  competing one.
+
+### Negative ❌
+
+- **Breaking change.** Any existing `m(format, args)` / `ctx(name, format, args)` call using `%`
+  conversions silently changes behavior — the `%` sequence is no longer substituted and appears literally
+  in the output, without a compile error (same method signature, `String, Object...`). This is
+  acceptable only because it ships as part of a major version bump, with the change called out
+  prominently in release notes; callers must audit and migrate call sites, either to `{}` placeholders
+  under `m`/`ctx` or to the equivalent `mf`/`ctxf` call.
+- **`{}` substitution cannot express `printf` features.** Width, padding, precision, and type-specific
+  conversions (`%.2f`, `%05d`) have no `{}` equivalent; callers needing them must use `mf`/`ctxf`, which
+  keeps the `Formatter` cost and the locale-pinning caveat below.
+- **The SAST blind spot is not fully closed.** `MessageFormatter.arrayFormat` is just as invisible to
+  static analyzers as the previous custom overload was; the mitigation is only that `mf`/`ctxf` are more
+  legible as an intentional `printf` escape hatch, not a structural fix.
+- **`mf`/`ctxf` output no longer respects the JVM default locale**, same tradeoff already accepted for
+  `UnitFormatter` in TDR-0040 — e.g. `mf("%.2f", 3.14)` always renders `3.14`, never `3,14`, regardless of
+  the running JVM's locale.
+
+### Neutral ⚖️
+
+- `MeterContext.ctxf`'s error path now stores `IllegalFormatException.getMessage()` instead of
+  `getLocalizedMessage()` — a small, deliberate consistency fix so even the failure text does not depend
+  on locale.
+
+## Alternatives Considered
+
+### ❌ Keep `m`/`ctx` as `printf`, add `Locale.ROOT` only (no renaming, no `{}` overload)
+
+**Description**: Pin the existing `printf` overloads to `Locale.ROOT` and stop there — no new methods,
+no breaking change.
+
+**Why rejected**: Removes the locale dependency but keeps the `Formatter` cost on the default path and
+leaves the SAST blind spot exactly as it was — the project decided the idiomatic slf4j `{}` convention
+and the performance win were worth a deliberate breaking change, given a major release was already
+planned.
+
+### ❌ Deprecate the `printf` overloads instead of renaming them
+
+**Description**: Keep `m`/`ctx` as `printf`-based (with `Locale.ROOT`), mark them
+`@Deprecated(forRemoval = true)`, and introduce the `{}` variant under new names (e.g. `mf`/`ctxf` for
+the *new* behavior).
+
+**Why rejected**: Considered and superseded by the maintainer's explicit decision to make the breaking
+change immediately, since a major release was already in scope — a deprecation cycle would only delay
+the ecosystem-consistency and performance benefits without avoiding a breaking change (the method names
+still change meaning or move).
+
+## Implementation
+
+- `src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java` — `validateMCallArgument(meter, format,
+  args)` reimplemented on `MessageFormatter.arrayFormat`; the previous `printf` implementation kept as
+  `validateMfCallArgument(meter, format, args)`, pinned to `Locale.ROOT`.
+- `src/main/java/org/usefultoys/slf4j/meter/Meter.java` — `m(String, Object...)` now `{}`-based; `printf`
+  behavior moved to new `mf(String, Object...)`.
+- `src/main/java/org/usefultoys/slf4j/meter/MeterContext.java` — same split for `ctx`/`ctxf`.
+- Existing tests migrated call-by-call: incidental `%s`/`%d` usage converted to `{}` under `m`/`ctx`;
+  tests specifically exercising `printf` semantics (illegal format detection, mismatched specifiers)
+  moved to `mf`/`ctxf`. New tests added for the `{}` semantics of `m`/`ctx` (`MeterValidatorTest`'s
+  `PlaceholderMessageArgumentsTests`, `MeterContextTest`'s `PlaceholderStrings`).
+
+## References
+
+- [TDR-0017: Non-Intrusive Validation and Error Handling](TDR-0017-non-intrusive-validation-and-error-handling.md)
+- [TDR-0039: Accept Scaled-Integer Rounding in JSON5 Serialization](TDR-0039-accept-scaled-integer-rounding-in-json5-serialization.md)
+- [TDR-0040: Locale-Independent Formatting for Human-Readable Messages](TDR-0040-locale-independent-readable-messages.md)
+- [TDR-0010: Simultaneous Support for slf4j 1.7/2.0 and Logback 1.2/1.5](TDR-0010-simultaneous-support-for-slf4j-1.7-2.0-and-logback-1.2-1.5.md)
+- [src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java](../src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java)
+- [src/main/java/org/usefultoys/slf4j/meter/Meter.java](../src/main/java/org/usefultoys/slf4j/meter/Meter.java)
+- [src/main/java/org/usefultoys/slf4j/meter/MeterContext.java](../src/main/java/org/usefultoys/slf4j/meter/MeterContext.java)

--- a/doc/TDR-0043-slf4j-placeholders-as-primary-meter-message-api.md
+++ b/doc/TDR-0043-slf4j-placeholders-as-primary-meter-message-api.md
@@ -1,4 +1,4 @@
-# TDR-0042: slf4j `{}` Placeholders as the Primary Meter Message API
+# TDR-0043: slf4j `{}` Placeholders as the Primary Meter Message API
 
 **Status**: Accepted
 **Date**: 2026-07-12

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -379,7 +379,7 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * Configures the `Meter` with a human-readable message that explains the operation's purpose, using a
      * {@code printf}-style format string.
      * <p>
-     * This overload is kept as a deliberate tradeoff (see TDR-0042): {@code java.util.Formatter} parses the format
+     * This overload is kept as a deliberate tradeoff (see TDR-0043): {@code java.util.Formatter} parses the format
      * string and allocates on every call, which {@link #m(String, Object...)} avoids. Formatting is pinned to
      * {@link java.util.Locale#ROOT}, so the result never depends on the JVM's default locale.
      * <p>
@@ -941,6 +941,11 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
 
         @Override
         public Meter m(final String format, final Object... args) {
+            return denied();
+        }
+
+        @Override
+        public Meter mf(final String format, final Object... args) {
             return denied();
         }
 

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -351,11 +351,14 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
     }
 
     /**
-     * Configures the `Meter` with a human-readable message that explains the operation's purpose, using a format
-     * string.
+     * Configures the `Meter` with a human-readable message that explains the operation's purpose, using an
+     * slf4j-style message pattern with {@code {}} placeholders (e.g., {@code m("User {} has {} points", user, n)}).
+     * <p>
+     * Formatting is locale-independent and does not allocate a {@link java.util.Formatter}. For
+     * {@code printf}-style formatting (e.g., {@code "%.2f"}), use {@link #mf(String, Object...)} instead.
      *
-     * @param format The message format string (e.g., `String.format(java.lang.String, java.lang.Object...)`).
-     * @param args   The arguments for the format string.
+     * @param format The message pattern using {@code {}} placeholders.
+     * @param args   The arguments substituted into the placeholders.
      * @return Reference to this `Meter` instance, for method chaining.
      */
     public Meter m(final String format, final Object... args) {
@@ -363,6 +366,26 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             return this;
         }
         description = MeterValidator.validateMCallArgument(this, format, args);
+        return this;
+    }
+
+    /**
+     * Configures the `Meter` with a human-readable message that explains the operation's purpose, using a
+     * {@code printf}-style format string.
+     * <p>
+     * This overload is kept as a deliberate tradeoff (see TDR-0042): {@code java.util.Formatter} parses the format
+     * string and allocates on every call, which {@link #m(String, Object...)} avoids. Formatting is pinned to
+     * {@link java.util.Locale#ROOT}, so the result never depends on the JVM's default locale.
+     *
+     * @param format The message format string (e.g., `String.format(java.lang.String, java.lang.Object...)`).
+     * @param args   The arguments for the format string.
+     * @return Reference to this `Meter` instance, for method chaining.
+     */
+    public Meter mf(final String format, final Object... args) {
+        if (!MeterValidator.validateMPrecondition(this)) {
+            return this;
+        }
+        description = MeterValidator.validateMfCallArgument(this, format, args);
         return this;
     }
 

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -356,6 +356,12 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * <p>
      * Formatting is locale-independent and does not allocate a {@link java.util.Formatter}. For
      * {@code printf}-style formatting (e.g., {@code "%.2f"}), use {@link #mf(String, Object...)} instead.
+     * <p>
+     * <b>Arguments are substituted immediately, at the moment this method is called</b> — unlike most other
+     * {@code Meter} attributes (e.g., elapsed time, throughput, iteration counts), which are computed later, when
+     * the log message is actually emitted (on {@code start()}/{@code progress()}/{@code ok()}/etc.). The resulting
+     * message is fixed at call time; if an argument's value changes afterward, the emitted message still reflects
+     * the value as it was when {@code m(...)} was called.
      *
      * @param format The message pattern using {@code {}} placeholders.
      * @param args   The arguments substituted into the placeholders.
@@ -376,6 +382,9 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * This overload is kept as a deliberate tradeoff (see TDR-0042): {@code java.util.Formatter} parses the format
      * string and allocates on every call, which {@link #m(String, Object...)} avoids. Formatting is pinned to
      * {@link java.util.Locale#ROOT}, so the result never depends on the JVM's default locale.
+     * <p>
+     * As with {@link #m(String, Object...)}, <b>arguments are substituted immediately, at the moment this method
+     * is called</b>, not when the log message is later emitted.
      *
      * @param format The message format string (e.g., `String.format(java.lang.String, java.lang.Object...)`).
      * @param args   The arguments for the format string.

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterContext.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterContext.java
@@ -254,6 +254,12 @@ public interface MeterContext<T extends MeterData> {
      * <p>
      * Formatting is locale-independent and does not allocate a {@link java.util.Formatter}. For
      * {@code printf}-style formatting (e.g., {@code "%.2f"}), use {@link #ctxf(String, String, Object...)} instead.
+     * <p>
+     * <b>Arguments are substituted immediately, at the moment this method is called</b> — unlike most other
+     * {@code Meter} attributes (e.g., elapsed time, throughput, iteration counts), which are computed later, when
+     * the log message is actually emitted (on {@code start()}/{@code progress()}/{@code ok()}/etc.). The resulting
+     * context value is fixed at call time; if an argument's value changes afterward, the emitted context still
+     * reflects the value as it was when {@code ctx(...)} was called.
      *
      * @param name   The key of the entry to add. Must not be {@code null}.
      * @param format The message pattern using {@code {}} placeholders. Must not be {@code null}.
@@ -275,6 +281,9 @@ public interface MeterContext<T extends MeterData> {
      * This overload is kept as a deliberate tradeoff (see TDR-0042): {@code java.util.Formatter} parses the format
      * string and allocates on every call, which {@link #ctx(String, String, Object...)} avoids. Formatting is
      * pinned to {@link Locale#ROOT}, so the result never depends on the JVM's default locale.
+     * <p>
+     * As with {@link #ctx(String, String, Object...)}, <b>arguments are substituted immediately, at the moment
+     * this method is called</b>, not when the log message is later emitted.
      *
      * @param name   The key of the entry to add. Must not be {@code null}.
      * @param format The message format string (e.g., `String.format(java.lang.String, java.lang.Object...)`). Must not

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterContext.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterContext.java
@@ -15,7 +15,10 @@
  */
 package org.usefultoys.slf4j.meter;
 
+import org.slf4j.helpers.MessageFormatter;
+
 import java.util.IllegalFormatException;
+import java.util.Locale;
 
 /**
  * An interface defining methods for managing contextual data within a {@link Meter} operation.
@@ -244,14 +247,17 @@ public interface MeterContext<T extends MeterData> {
         return (T) this;
     }
 
-    
+
     /**
-     * Adds a key-value entry to the context map, where the value is a formatted message.
+     * Adds a key-value entry to the context map, where the value is a message formatted using slf4j-style
+     * {@code {}} placeholders (e.g., {@code ctx("status", "User {} has {} points", user, n)}).
+     * <p>
+     * Formatting is locale-independent and does not allocate a {@link java.util.Formatter}. For
+     * {@code printf}-style formatting (e.g., {@code "%.2f"}), use {@link #ctxf(String, String, Object...)} instead.
      *
      * @param name   The key of the entry to add. Must not be {@code null}.
-     * @param format The message format string (e.g., `String.format(java.lang.String, java.lang.Object...)`). Must not
-     *               be {@code null}.
-     * @param args   The arguments for the format string.
+     * @param format The message pattern using {@code {}} placeholders. Must not be {@code null}.
+     * @param args   The arguments substituted into the placeholders.
      * @return Reference to this `MeterContext` instance, for method chaining.
      */
     default T ctx(final String name, final String format, final Object... args) {
@@ -259,10 +265,32 @@ public interface MeterContext<T extends MeterData> {
             putContext(name, "<null format>");
             return (T) this;
         }
+        putContext(name, MessageFormatter.arrayFormat(format, args).getMessage());
+        return (T) this;
+    }
+
+    /**
+     * Adds a key-value entry to the context map, where the value is a {@code printf}-formatted message.
+     * <p>
+     * This overload is kept as a deliberate tradeoff (see TDR-0042): {@code java.util.Formatter} parses the format
+     * string and allocates on every call, which {@link #ctx(String, String, Object...)} avoids. Formatting is
+     * pinned to {@link Locale#ROOT}, so the result never depends on the JVM's default locale.
+     *
+     * @param name   The key of the entry to add. Must not be {@code null}.
+     * @param format The message format string (e.g., `String.format(java.lang.String, java.lang.Object...)`). Must not
+     *               be {@code null}.
+     * @param args   The arguments for the format string.
+     * @return Reference to this `MeterContext` instance, for method chaining.
+     */
+    default T ctxf(final String name, final String format, final Object... args) {
+        if (format == null) {
+            putContext(name, "<null format>");
+            return (T) this;
+        }
         try {
-            putContext(name, String.format(format, args));
+            putContext(name, String.format(Locale.ROOT, format, args));
         } catch (final IllegalFormatException e) {
-            putContext(name, e.getLocalizedMessage());
+            putContext(name, e.getMessage());
         }
         return (T) this;
     }

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterContext.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterContext.java
@@ -278,7 +278,7 @@ public interface MeterContext<T extends MeterData> {
     /**
      * Adds a key-value entry to the context map, where the value is a {@code printf}-formatted message.
      * <p>
-     * This overload is kept as a deliberate tradeoff (see TDR-0042): {@code java.util.Formatter} parses the format
+     * This overload is kept as a deliberate tradeoff (see TDR-0043): {@code java.util.Formatter} parses the format
      * string and allocates on every call, which {@link #ctx(String, String, Object...)} avoids. Formatting is
      * pinned to {@link Locale#ROOT}, so the result never depends on the JVM's default locale.
      * <p>

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
@@ -88,7 +88,7 @@ public class MeterValidator {
      * Meter.
      * <p>
      * This overload is kept as a deliberate tradeoff: {@code java.util.Formatter} parses the format string and
-     * allocates on every call (see TDR-0042), which the {@code {}}-placeholder {@code m} overload avoids. Formatting
+     * allocates on every call (see TDR-0043), which the {@code {}}-placeholder {@code m} overload avoids. Formatting
      * is pinned to {@link Locale#ROOT} so the result never depends on the JVM's default locale.
      *
      * @param meter  The Meter instance.

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
@@ -17,9 +17,11 @@ package org.usefultoys.slf4j.meter;
 
 import lombok.experimental.UtilityClass;
 
+import org.slf4j.helpers.MessageFormatter;
 import org.usefultoys.slf4j.CallerStackTraceThrowable;
 
 import java.util.IllegalFormatException;
+import java.util.Locale;
 
 /**
  * A utility class responsible for validating the state of a {@link Meter} instance before executing an operation.
@@ -65,20 +67,42 @@ public class MeterValidator {
     }
 
     /**
-     * Validates and formats the arguments for the `m` method (message with format) of a Meter.
+     * Validates and formats the arguments for the `m` method (message with slf4j-style {@code {}} placeholders) of a
+     * Meter.
      *
      * @param meter  The Meter instance.
-     * @param format The message format string.
-     * @param args   The arguments for the format string.
-     * @return The formatted string, or {@code null} if the format is null or invalid.
+     * @param format The message pattern using slf4j {@code {}} placeholders.
+     * @param args   The arguments substituted into the placeholders.
+     * @return The formatted string, or {@code null} if the format is null.
      */
     String validateMCallArgument(final Meter meter, final String format, final Object... args) {
         if (format == null) {
             logInvalidArgument(meter, "Null argument: format");
             return null;
         }
+        return MessageFormatter.arrayFormat(format, args).getMessage();
+    }
+
+    /**
+     * Validates and formats the arguments for the `mf` method (message with {@code printf}-style format) of a
+     * Meter.
+     * <p>
+     * This overload is kept as a deliberate tradeoff: {@code java.util.Formatter} parses the format string and
+     * allocates on every call (see TDR-0042), which the {@code {}}-placeholder {@code m} overload avoids. Formatting
+     * is pinned to {@link Locale#ROOT} so the result never depends on the JVM's default locale.
+     *
+     * @param meter  The Meter instance.
+     * @param format The {@code printf}-style format string.
+     * @param args   The arguments for the format string.
+     * @return The formatted string, or {@code null} if the format is null or invalid.
+     */
+    String validateMfCallArgument(final Meter meter, final String format, final Object... args) {
+        if (format == null) {
+            logInvalidArgument(meter, "Null argument: format");
+            return null;
+        }
         try {
-            return String.format(format, args);
+            return String.format(Locale.ROOT, format, args);
         } catch (final IllegalFormatException e) {
             logInvalidArgument(meter, "Illegal format string");
             return null;

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterContextTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterContextTest.java
@@ -352,13 +352,13 @@ class MeterContextTest {
     }
 
     @Nested
-    @DisplayName("Formatted Strings")
+    @DisplayName("Formatted Strings (printf, ctxf)")
     class FormattedStrings {
         @Test
-        @DisplayName("ctx(name, format, args) should add key with formatted string value")
-        void shouldAddKeyWithFormattedStringValueWhenCtxWithKeyAndFormat() {
-            // When: ctx is called with key, format, and arg
-            meterContext.ctx("key9", "formatted %d", 100);
+        @DisplayName("ctxf(name, format, args) should add key with formatted string value")
+        void shouldAddKeyWithFormattedStringValueWhenCtxfWithKeyAndFormat() {
+            // When: ctxf is called with key, format, and arg
+            meterContext.ctxf("key9", "formatted %d", 100);
 
             // Then: the context map should contain the key with the formatted string value
             assertFalse(meterContext.getContext().isEmpty(), "should not be empty after adding key");
@@ -367,15 +367,69 @@ class MeterContextTest {
         }
 
         @Test
-        @DisplayName("ctx(name, format, args) with null name should add entry with NULL_VALUE key and formatted value")
-        void shouldAddNullValueKeyWithFormattedValueWhenCtxWithNullNameAndFormat() {
-            // When: ctx is called with null name, format, and arg
-            meterContext.ctx(null, "formatted %d", 100);
+        @DisplayName("ctxf(name, format, args) with null name should add entry with NULL_VALUE key and formatted value")
+        void shouldAddNullValueKeyWithFormattedValueWhenCtxfWithNullNameAndFormat() {
+            // When: ctxf is called with null name, format, and arg
+            meterContext.ctxf(null, "formatted %d", 100);
 
             // Then: the context map should contain NULL_VALUE as key with formatted value
             assertFalse(meterContext.getContext().isEmpty(), "should not be empty");
             assertTrue(meterContext.getContext().containsKey(NULL_VALUE), "should contain NULL_VALUE as key");
             assertEquals("formatted 100", meterContext.getContext().get(NULL_VALUE), "should have formatted value");
+        }
+
+        @Test
+        @DisplayName("ctxf(name, format, args) with null format should add entry with '<null format>' value")
+        void shouldAddNullFormatValueWhenCtxfWithKeyAndNullFormat() {
+            // When: ctxf is called with key and null format
+            meterContext.ctxf("key", null, 100);
+
+            // Then: the context map should contain the key with '<null format>' value
+            assertFalse(meterContext.getContext().isEmpty(), "should not be empty");
+            assertTrue(meterContext.getContext().containsKey("key"), "should contain the key");
+            assertEquals("<null format>", meterContext.getContext().get("key"), "should have '<null format>' as value");
+        }
+
+        @Test
+        @DisplayName("ctxf(name, format, args) with illegal format should add entry with exception message")
+        void shouldAddExceptionMessageWhenCtxfWithIllegalFormat() {
+            // When: ctxf is called with illegal format
+            meterContext.ctxf("key", "%d", "not an int");
+
+            // Then: the context map should contain the key with non-null value (exception message)
+            assertFalse(meterContext.getContext().isEmpty(), "should not be empty");
+            assertTrue(meterContext.getContext().containsKey("key"), "should contain the key");
+            assertNotNull(meterContext.getContext().get("key"), "should have non-null value");
+            // The exact message can vary by JVM/Locale, so we check for presence and type
+            assertTrue(meterContext.getContext().get("key").contains("java.lang.String"), "Value should contain format exception message");
+        }
+    }
+
+    @Nested
+    @DisplayName("Placeholder Strings ({}, ctx)")
+    class PlaceholderStrings {
+        @Test
+        @DisplayName("ctx(name, format, args) should add key with substituted string value")
+        void shouldAddKeyWithSubstitutedStringValueWhenCtxWithKeyAndFormat() {
+            // When: ctx is called with key, {} pattern, and arg
+            meterContext.ctx("key9", "formatted {}", 100);
+
+            // Then: the context map should contain the key with the substituted string value
+            assertFalse(meterContext.getContext().isEmpty(), "should not be empty after adding key");
+            assertTrue(meterContext.getContext().containsKey("key9"), "should contain the added key");
+            assertEquals("formatted 100", meterContext.getContext().get("key9"), "should have 'formatted 100' as value");
+        }
+
+        @Test
+        @DisplayName("ctx(name, format, args) with null name should add entry with NULL_VALUE key and substituted value")
+        void shouldAddNullValueKeyWithSubstitutedValueWhenCtxWithNullNameAndFormat() {
+            // When: ctx is called with null name, {} pattern, and arg
+            meterContext.ctx(null, "formatted {}", 100);
+
+            // Then: the context map should contain NULL_VALUE as key with substituted value
+            assertFalse(meterContext.getContext().isEmpty(), "should not be empty");
+            assertTrue(meterContext.getContext().containsKey(NULL_VALUE), "should contain NULL_VALUE as key");
+            assertEquals("formatted 100", meterContext.getContext().get(NULL_VALUE), "should have substituted value");
         }
 
         @Test
@@ -391,17 +445,15 @@ class MeterContextTest {
         }
 
         @Test
-        @DisplayName("ctx(name, format, args) with illegal format should add entry with exception message")
-        void shouldAddExceptionMessageWhenCtxWithIllegalFormat() {
-            // When: ctx is called with illegal format
+        @DisplayName("ctx(name, format, args) never throws, unlike printf ctxf(): mismatched pattern is left literal")
+        void shouldLeaveLiteralTextWhenNoPlaceholderPresent() {
+            // When: ctx is called with a pattern containing no {} placeholder
             meterContext.ctx("key", "%d", "not an int");
 
-            // Then: the context map should contain the key with non-null value (exception message)
+            // Then: the context map should contain the key with the literal, unsubstituted pattern
             assertFalse(meterContext.getContext().isEmpty(), "should not be empty");
             assertTrue(meterContext.getContext().containsKey("key"), "should contain the key");
-            assertNotNull(meterContext.getContext().get("key"), "should have non-null value");
-            // The exact message can vary by JVM/Locale, so we check for presence and type
-            assertTrue(meterContext.getContext().get("key").contains("java.lang.String"), "Value should contain format exception message");
+            assertEquals("%d", meterContext.getContext().get("key"), "should leave literal text untouched");
         }
     }
 

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStartConfigurationTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStartConfigurationTest.java
@@ -159,7 +159,7 @@ class MeterLifeCyclePostStartConfigurationTest {
         final TimeRecord tr = fromStarted(meter);
 
         // When: m(format, args) is called after start()
-        meter.m("step %d", 1);
+        meter.m("step {}", 1);
 
         // Then: description attribute is formatted and stored correctly
         assertEquals("step 1", meter.getDescription());
@@ -179,8 +179,8 @@ class MeterLifeCyclePostStartConfigurationTest {
         final TimeRecord tr = fromStarted(meter);
 
         // When: m(format, args) is called multiple times
-        meter.m("step %d", 1);
-        meter.m("step %d", 2);
+        meter.m("step {}", 1);
+        meter.m("step {}", 2);
 
         // Then: last value wins
         assertEquals("step 2", meter.getDescription());
@@ -199,8 +199,8 @@ class MeterLifeCyclePostStartConfigurationTest {
         final Meter meter = new Meter(logger).start();
         final TimeRecord tr = fromStarted(meter);
 
-        // When: m("valid: %s", "arg") is called, then m(null, "arg") is attempted
-        meter.m("valid: %s", "arg");
+        // When: m("valid: {}", "arg") is called, then m(null, "arg") is attempted
+        meter.m("valid: {}", "arg");
         meter.m(null, "arg");
 
         // Then: null format rejected (logs INVALID_ARGUMENT), previous description is lost
@@ -216,15 +216,15 @@ class MeterLifeCyclePostStartConfigurationTest {
     }
 
     @Test
-    @DisplayName("should log INVALID_ARGUMENT when invalid format string attempted after start()")
+    @DisplayName("should log INVALID_ARGUMENT when invalid printf format string attempted after start()")
     @ValidateCleanMeter(expectDirtyStack = true)
     void shouldLogIllegalWhenInvalidFormatStringAttemptedAfterStart() {
         // Given: a new, started Meter
         final Meter meter = new Meter(logger).start();
         final TimeRecord tr = fromStarted(meter);
 
-        // When: m("invalid format %z", "arg") is called (invalid format specifier)
-        meter.m("invalid format %z", "arg");
+        // When: mf("invalid format %z", "arg") is called (invalid printf format specifier)
+        meter.mf("invalid format %z", "arg");
 
         // Then: description remains null and meter remains in Started state
         assertNull(meter.getDescription());
@@ -232,9 +232,9 @@ class MeterLifeCyclePostStartConfigurationTest {
         MeterLifeCycleTestHelper.assertMeterStartTime(meter, tr);
 
         // Then: logs start + INVALID_ARGUMENT
-        AssertLogger.assertEvent(logger, 2, ERROR, INVALID_ARGUMENT, "Meter.m", "Illegal format string", meter.getFullID());
+        AssertLogger.assertEvent(logger, 2, ERROR, INVALID_ARGUMENT, "Meter.mf", "Illegal format string", meter.getFullID());
         AssertLogger.assertEventWithThrowable(logger, 2, CallerStackTraceThrowable.class);
-        AssertLogger.assertEventThrowableStackTraceContains(logger, 2, CallerStackTraceThrowable.class, "Meter.m(");
+        AssertLogger.assertEventThrowableStackTraceContains(logger, 2, CallerStackTraceThrowable.class, "Meter.mf(");
         AssertLogger.assertEventCount(logger, 3);
     }
 
@@ -1095,8 +1095,8 @@ class MeterLifeCyclePostStartConfigurationTest {
         final Meter meter = new Meter(logger).start();
         final TimeRecord tr = fromStarted(meter);
 
-        // When: ctx("status", "User %s has %d points", "Alice", 150) is called after start()
-        meter.ctx("status", "User %s has %d points", "Alice", 150);
+        // When: ctx("status", "User {} has {} points", "Alice", 150) is called after start()
+        meter.ctx("status", "User {} has {} points", "Alice", 150);
 
         // Then: context contains the formatted message
         assertEquals("User Alice has 150 points", meter.getContext().get("status"));

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStopInvalidOperationsFailedStateTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStopInvalidOperationsFailedStateTest.java
@@ -130,8 +130,8 @@ class MeterLifeCyclePostStopInvalidOperationsFailedStateTest {
         // Then: meter start and stop time are set correctly
         assertMeterStopTime(meter, tr);
 
-        // When: m("step %d", 1) is called after stop
-        meter.m("step %d", 1);
+        // When: m("step {}", 1) is called after stop
+        meter.m("step {}", 1);
 
         // Then: description unchanged (null), state unchanged after invalid operation
         assertNull(meter.getDescription(), "should not update description after stop");
@@ -718,8 +718,8 @@ class MeterLifeCyclePostStopInvalidOperationsFailedStateTest {
         // Then: meter start and stop time are set correctly
         assertMeterStopTime(meter, tr);
 
-        // When: ctx("key", "value %d", 42) is called after stop
-        meter.ctx("key", "value %d", 42);
+        // When: ctx("key", "value {}", 42) is called after stop
+        meter.ctx("key", "value {}", 42);
 
         // Then: context unchanged, state unchanged after invalid operation
         assertFalse(meter.getContext().containsKey("key"), "should not add context after stop");
@@ -1173,8 +1173,8 @@ class MeterLifeCyclePostStopInvalidOperationsFailedStateTest {
         // Then: meter start and stop time are set correctly
         assertMeterStopTime(meter, tr);
 
-        // When: ctx(null, "format %d", 42) is called after stop
-        meter.ctx(null, "format %d", 42);
+        // When: ctx(null, "format {}", 42) is called after stop
+        meter.ctx(null, "format {}", 42);
 
         // Then: context unchanged, state unchanged after invalid operation
         assertMeterState(meter, true, true, null, null, "technical_error", null, 0, 0, 0);

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStopInvalidOperationsOkStateTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStopInvalidOperationsOkStateTest.java
@@ -150,6 +150,34 @@ class MeterLifeCyclePostStopInvalidOperationsOkStateTest {
     }
 
     @Test
+    @DisplayName("should reject mf(String, Object...) after ok() - logs INVALID_ARGUMENT")
+    @ValidateCleanMeter
+    void shouldRejectPrintfDescriptionWithArgsAfterOk() {
+        // Given: a meter that has been stopped with ok()
+        final Meter meter = new Meter(logger).start();
+        final TimeRecord tr = fromStarted(meter);
+        recordStopWithWindow(tr, meter::ok);
+        // Then: meter start and stop time are set correctly
+        assertMeterStopTime(meter, tr);
+
+        // When: mf("step %d", 1) is called after stop
+        meter.mf("step %d", 1);
+
+        // Then: description unchanged (null), state unchanged after invalid operation
+        assertNull(meter.getDescription(), "should not update description after stop");
+        MeterLifeCycleTestHelper.assertMeterState(meter, true, true, null, null, null, null, 0, 0, 0);
+        assertMeterStopTime(meter, tr);
+
+        // Then: logs ok (from setup) + INVALID_ARGUMENT (from invalid operation)
+        AssertLogger.assertEvent(logger, 2, MockLoggerEvent.Level.INFO, Markers.MSG_OK);
+        AssertLogger.assertEvent(logger, 3, MockLoggerEvent.Level.TRACE, Markers.DATA_OK);
+        AssertLogger.assertEvent(logger, 4, MockLoggerEvent.Level.ERROR, Markers.INVALID_STATE, "Meter.mf", "Meter already stopped", meter.getFullID());
+        AssertLogger.assertEventWithThrowable(logger, 4, CallerStackTraceThrowable.class);
+        AssertLogger.assertEventThrowableStackTraceContains(logger, 4, CallerStackTraceThrowable.class, "Meter.mf(");
+        AssertLogger.assertEventCount(logger, 5);
+    }
+
+    @Test
     @DisplayName("should reject m(null) after ok() - logs INVALID_ARGUMENT")
     @ValidateCleanMeter
     void shouldRejectNullDescriptionAfterOk() {

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStopInvalidOperationsOkStateTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStopInvalidOperationsOkStateTest.java
@@ -132,8 +132,8 @@ class MeterLifeCyclePostStopInvalidOperationsOkStateTest {
         // Then: meter start and stop time are set correctly
         assertMeterStopTime(meter, tr);
 
-        // When: m("step %d", 1) is called after stop
-        meter.m("step %d", 1);
+        // When: m("step {}", 1) is called after stop
+        meter.m("step {}", 1);
 
         // Then: description unchanged (null), state unchanged after invalid operation
         assertNull(meter.getDescription(), "should not update description after stop");
@@ -216,8 +216,8 @@ class MeterLifeCyclePostStopInvalidOperationsOkStateTest {
         // Then: meter start and stop time are set correctly
         assertMeterStopTime(meter, tr);
 
-        // When: m("step %d", 1) is called after stop
-        meter.m("step %d", 1);
+        // When: m("step {}", 1) is called after stop
+        meter.m("step {}", 1);
 
         // Then: description unchanged (null), state unchanged after invalid operation
         assertNull(meter.getDescription(), "should not update description after stop");
@@ -1006,8 +1006,8 @@ class MeterLifeCyclePostStopInvalidOperationsOkStateTest {
         // Then: meter start and stop time are set correctly
         assertMeterStopTime(meter, tr);
 
-        // When: ctx("key", "value %d", 42) is called after stop
-        meter.ctx("key", "value %d", 42);
+        // When: ctx("key", "value {}", 42) is called after stop
+        meter.ctx("key", "value {}", 42);
 
         // Then: context unchanged, state unchanged after invalid operation
         assertFalse(meter.getContext().containsKey("key"), "should not add context after stop");

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStopInvalidOperationsRejectedStateTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePostStopInvalidOperationsRejectedStateTest.java
@@ -132,8 +132,8 @@ class MeterLifeCyclePostStopInvalidOperationsRejectedStateTest {
         // Then: meter start and stop time are set correctly
         assertMeterStopTime(meter, tr);
 
-        // When: m("step %d", 1) is called after stop
-        meter.m("step %d", 1);
+        // When: m("step {}", 1) is called after stop
+        meter.m("step {}", 1);
 
         // Then: description unchanged (null), state unchanged after invalid operation
         assertNull(meter.getDescription(), "should not update description after stop");
@@ -721,8 +721,8 @@ class MeterLifeCyclePostStopInvalidOperationsRejectedStateTest {
         // Then: meter start and stop time are set correctly
         assertMeterStopTime(meter, tr);
 
-        // When: ctx("key", "value %d", 42) is called after stop
-        meter.ctx("key", "value %d", 42);
+        // When: ctx("key", "value {}", 42) is called after stop
+        meter.ctx("key", "value {}", 42);
 
         // Then: context unchanged, state unchanged after invalid operation
         assertFalse(meter.getContext().containsKey("key"), "should not add context after stop");

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePreStartConfigurationTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterLifeCyclePreStartConfigurationTest.java
@@ -351,7 +351,7 @@ class MeterLifeCyclePreStartConfigurationTest {
         final Meter meter = recordCreateWithWindow(tr, () -> new Meter(logger));
 
         // When: m(format, args) is called before start()
-        meter.m("operation %s", "doWork");
+        meter.m("operation {}", "doWork");
 
         // Then: description attribute is formatted and stored correctly and meter remains in Created state
         assertEquals("operation doWork", meter.getDescription(), "should format description correctly");
@@ -370,8 +370,8 @@ class MeterLifeCyclePreStartConfigurationTest {
         final Meter meter = recordCreateWithWindow(tr, () -> new Meter(logger));
 
         // When: m(format, args) is called multiple times
-        meter.m("step %d", 1);
-        meter.m("step %d", 2);
+        meter.m("step {}", 1);
+        meter.m("step {}", 2);
 
         // Then: last value wins and meter remains in Created state
         assertEquals("step 2", meter.getDescription(), "should override with last formatted value");
@@ -389,8 +389,8 @@ class MeterLifeCyclePreStartConfigurationTest {
         final TimeRecord tr = new TimeRecord();
         final Meter meter = recordCreateWithWindow(tr, () -> new Meter(logger));
 
-        // When: m("valid: %s", "arg") is called, then m(null, "arg") is attempted
-        meter.m("valid: %s", "arg");
+        // When: m("valid: {}", "arg") is called, then m(null, "arg") is attempted
+        meter.m("valid: {}", "arg");
         meter.m(null, "arg");
 
         // Then: null format is rejected with INVALID_ARGUMENT log, description is reset to null, meter remains in Created state
@@ -406,14 +406,14 @@ class MeterLifeCyclePreStartConfigurationTest {
     }
 
     @Test
-    @DisplayName("should log INVALID_ARGUMENT when invalid format string attempted")
+    @DisplayName("should log INVALID_ARGUMENT when invalid printf format string attempted")
     void shouldLogIllegalWhenInvalidFormatStringAttempted() {
         // Given: a new Meter
         final TimeRecord tr = new TimeRecord();
         final Meter meter = recordCreateWithWindow(tr, () -> new Meter(logger));
 
-        // When: m("invalid format %z", "arg") is called (invalid format specifier)
-        meter.m("invalid format %z", "arg");
+        // When: mf("invalid format %z", "arg") is called (invalid printf format specifier)
+        meter.mf("invalid format %z", "arg");
 
         // Then: meter remains in Created state with no description set
         assertNull(meter.getDescription(), "should remain null when invalid format attempted");
@@ -421,9 +421,9 @@ class MeterLifeCyclePreStartConfigurationTest {
         assertMeterCreateTime(meter, tr);
 
         // Then: INVALID_ARGUMENT event logged
-        assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT, "Meter.m", "Illegal format string", meter.getFullID());
+        assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT, "Meter.mf", "Illegal format string", meter.getFullID());
         AssertLogger.assertEventWithThrowable(logger, 0, CallerStackTraceThrowable.class);
-        AssertLogger.assertEventThrowableStackTraceContains(logger, 0, CallerStackTraceThrowable.class, "Meter.m(");
+        AssertLogger.assertEventThrowableStackTraceContains(logger, 0, CallerStackTraceThrowable.class, "Meter.mf(");
         assertEventCount(logger, 1);
     }
 
@@ -741,8 +741,8 @@ class MeterLifeCyclePreStartConfigurationTest {
         final TimeRecord tr = new TimeRecord();
         final Meter meter = recordCreateWithWindow(tr, () -> new Meter(logger));
 
-        // When: ctx("key", "value %d", 42) is called before start()
-        meter.ctx("key", "value %d", 42);
+        // When: ctx("key", "value {}", 42) is called before start()
+        meter.ctx("key", "value {}", 42);
 
         // Then: context contains the formatted key-value pair and meter remains in Created state
         assertEquals("value 42", meter.getContext().get("key"), "should store formatted value as string");

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java
@@ -104,7 +104,16 @@ class MeterUnknownInstanceTest {
     @DisplayName("m(String, Object...) logs an invalid transition")
     void mWithFormatLogsInvalidTransition() {
         final Meter unknown = Meter.getCurrentInstance();
-        final Meter result = unknown.m("value=%d", 42);
+        final Meter result = unknown.m("value={}", 42);
+        assertSame(unknown, result);
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("mf(String, Object...) logs an invalid transition")
+    void mfWithFormatLogsInvalidTransition() {
+        final Meter unknown = Meter.getCurrentInstance();
+        final Meter result = unknown.mf("value=%d", 42);
         assertSame(unknown, result);
         unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
     }

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterValidatorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterValidatorTest.java
@@ -252,23 +252,70 @@ public class MeterValidatorTest {
     }
 
     @Nested
-    @DisplayName("Format and Message Arguments Tests")
+    @DisplayName("Format and Message Arguments Tests (printf, mf)")
     class FormatAndMessageArgumentsTests {
 
         @Test
         @DisplayName("should format message with arguments when format is valid")
-        void shouldValidateAndFormatMCallArgumentWhenOk() {
+        void shouldValidateAndFormatMfCallArgumentWhenOk() {
             // Given: a valid format string and arguments
-            // When: validateMCallArgument is called
+            // When: validateMfCallArgument is called
             // Then: should return formatted message and not log any events
-            assertEquals("message 1", MeterValidator.validateMCallArgument(meter, "message %d", 1), "should format message correctly");
+            assertEquals("message 1", MeterValidator.validateMfCallArgument(meter, "message %d", 1), "should format message correctly");
             assertNoEvents(logger);
         }
 
         @Test
         @DisplayName("should reject format when message is null")
-        void shouldValidateAndFormatMCallArgumentWhenNull() {
+        void shouldValidateAndFormatMfCallArgumentWhenNull() {
             // Given: a null message format string
+            // When: validateMfCallArgument is called
+            // Then: should return null and log illegal argument error
+            assertNull(MeterValidator.validateMfCallArgument(meter, null, 1), "should return null for null format");
+            assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT, "Null argument: format; id=test-id");
+            assertEventWithThrowable(logger, 0, CallerStackTraceThrowable.class);
+        }
+
+        @Test
+        @DisplayName("should format message with extra arguments when there are too many args")
+        void shouldValidateAndFormatMfCallArgumentWhenIllegalFormat1() {
+            // Given: format string with fewer specifiers than provided arguments
+            // When: validateMfCallArgument is called
+            // Then: String.format handles it gracefully by returning formatted message
+            assertEquals("message 1", MeterValidator.validateMfCallArgument(meter, "message %s", 1, 2), "should format message with extra args");
+            assertNoEvents(logger);
+        }
+
+        @Test
+        @DisplayName("should reject format when argument type does not match specifier")
+        void shouldValidateAndFormatMfCallArgumentWhenIllegalFormat2() {
+            // Given: format string with %d specifier but string argument
+            // When: validateMfCallArgument is called
+            // Then: should return null and log illegal format error
+            assertNull(MeterValidator.validateMfCallArgument(meter, "message %d", "s"), "should return null for mismatched format");
+            assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT, "Illegal format string; id=test-id");
+            assertEventWithThrowable(logger, 0, CallerStackTraceThrowable.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Placeholder Message Arguments Tests ({}, m)")
+    class PlaceholderMessageArgumentsTests {
+
+        @Test
+        @DisplayName("should substitute {} placeholders when format is valid")
+        void shouldValidateAndFormatMCallArgumentWhenOk() {
+            // Given: a valid {} placeholder pattern and arguments
+            // When: validateMCallArgument is called
+            // Then: should return substituted message and not log any events
+            assertEquals("message 1", MeterValidator.validateMCallArgument(meter, "message {}", 1), "should substitute placeholder correctly");
+            assertNoEvents(logger);
+        }
+
+        @Test
+        @DisplayName("should reject when format is null")
+        void shouldValidateAndFormatMCallArgumentWhenNull() {
+            // Given: a null message pattern
             // When: validateMCallArgument is called
             // Then: should return null and log illegal argument error
             assertNull(MeterValidator.validateMCallArgument(meter, null, 1), "should return null for null format");
@@ -277,24 +324,23 @@ public class MeterValidatorTest {
         }
 
         @Test
-        @DisplayName("should format message with extra arguments when there are too many args")
-        void shouldValidateAndFormatMCallArgumentWhenIllegalFormat1() {
-            // Given: format string with fewer specifiers than provided arguments
+        @DisplayName("should ignore extra arguments beyond the number of placeholders")
+        void shouldValidateAndFormatMCallArgumentWithExtraArgs() {
+            // Given: fewer {} placeholders than provided arguments
             // When: validateMCallArgument is called
-            // Then: String.format handles it gracefully by returning formatted message
-            assertEquals("message 1", MeterValidator.validateMCallArgument(meter, "message %s", 1, 2), "should format message with extra args");
+            // Then: MessageFormatter substitutes only the placeholders present, ignoring extra args
+            assertEquals("message 1", MeterValidator.validateMCallArgument(meter, "message {}", 1, 2), "should substitute only present placeholders");
             assertNoEvents(logger);
         }
 
         @Test
-        @DisplayName("should reject format when argument type does not match specifier")
-        void shouldValidateAndFormatMCallArgumentWhenIllegalFormat2() {
-            // Given: format string with %d specifier but string argument
+        @DisplayName("should never log illegal format, unlike printf mf()")
+        void shouldNeverRejectMismatchedArgumentType() {
+            // Given: a pattern whose literal text happens to look like a printf specifier
             // When: validateMCallArgument is called
-            // Then: should return null and log illegal format error
-            assertNull(MeterValidator.validateMCallArgument(meter, "message %d", "s"), "should return null for mismatched format");
-            assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT, "Illegal format string; id=test-id");
-            assertEventWithThrowable(logger, 0, CallerStackTraceThrowable.class);
+            // Then: no substitution occurs (no {} present), no exception, no log event
+            assertEquals("value %d", MeterValidator.validateMCallArgument(meter, "value %d", "non-integer"), "should leave literal text untouched");
+            assertNoEvents(logger);
         }
     }
 
@@ -742,11 +788,11 @@ public class MeterValidatorTest {
         void shouldLogIllegalCallArgumentWithIllegalFormatMessage() {
             // Given: an invalid format string
             final String message = "Illegal format string";
-            // When: validateMCallArgument is called with invalid format
+            // When: validateMfCallArgument is called with invalid format
             // Then: should log illegal argument marker
-            MeterValidator.validateMCallArgument(meter, "value %d", "non-integer");
+            MeterValidator.validateMfCallArgument(meter, "value %d", "non-integer");
             assertEvent(logger, 0, MockLoggerEvent.Level.ERROR, Markers.INVALID_ARGUMENT,
-                    "Meter.validateMCallArgument", message, "test-id");
+                    "Meter.validateMfCallArgument", message, "test-id");
             assertEventWithThrowable(logger, 0, CallerStackTraceThrowable.class);
         }
 


### PR DESCRIPTION
## Context

`Meter.m(String, Object...)` and `MeterContext.ctx(String, String, Object...)` let application code
attach a formatted message to an operation or its context. After [TDR-0039](https://github.com/useful-toys/slf4j-toys/blob/main/doc/TDR-0039-accept-scaled-integer-rounding-in-json5-serialization.md)
and [TDR-0040](https://github.com/useful-toys/slf4j-toys/blob/main/doc/TDR-0040-locale-independent-readable-messages.md)
removed locale dependence from the JSON5 and readable-message paths, these two overloads were the
**last locale-dependent operations remaining in the `Meter` subsystem** — both formatted with
`java.util.Formatter` (`String.format`), which parses the format string, allocates a `Formatter`,
autoboxes its arguments, and performs a JVM-default-locale lookup on every call.

## Problem

```java
meter.m("Total: %.2f", amount);   // renders "Total: 1,50" or "Total: 1.50" depending on JVM locale ❌
```

Two more costs compounded this:

- **Eager, unconditional `Formatter` cost** on every call, regardless of whether the log line that
  consumes the message is even enabled.
- **A static-analysis blind spot**: SAST/lint tools that flag malformed `printf` calls (Sonar
  `java:S2275`, IntelliJ `MalformedFormatString`, Error Prone `FormatString`) only recognize a fixed
  list of well-known methods (`String.format`, `printf`, ...). A project-defined `m(String,
  Object...)` is invisible to them, so a malformed format string compiles silently and is only caught
  at runtime by `MeterValidator`'s own `try/catch`, which logs a warning instead of failing the build.

## Solution

**`m`/`ctx` are redefined to use slf4j-idiomatic `{}` placeholders** (`MessageFormatter.arrayFormat`) —
no `Formatter`, no locale lookup, never throws. The previous `printf` behavior is **kept, renamed to
`mf`/`ctxf`**, and pinned to `Locale.ROOT` so it's deterministic instead of environment-dependent.
Documented as **TDR-0043**, including the alternatives considered (keep printf + `Locale.ROOT` only;
deprecate instead of rename) and why they were rejected in favor of a clean break, since a major
release was already planned.

- **`MeterValidator.validateMCallArgument(meter, format, args)`** reimplemented on
  `MessageFormatter.arrayFormat`; previous printf implementation kept as
  **`validateMfCallArgument(...)`**, using `Locale.ROOT`.
- **`Meter.m(String, Object...)`** now `{}`-based; printf moved to new **`Meter.mf(String,
  Object...)`**.
- **`MeterContext.ctx(name, format, args)`** now `{}`-based; printf moved to new
  **`MeterContext.ctxf(name, format, args)`** (also fixes its error path: `getMessage()` instead of
  locale-dependent `getLocalizedMessage()`).
- Uses `MessageFormatter.arrayFormat` — **not** the slf4j-2.0-only `basicArrayFormat` — so the
  implementation works unmodified on both slf4j 1.7 and 2.0, which this project supports
  simultaneously ([TDR-0010](https://github.com/useful-toys/slf4j-toys/blob/main/doc/TDR-0010-simultaneous-support-for-slf4j-1.7-2.0-and-logback-1.2-1.5.md)).
  No new dependency — `slf4j-api` already provides `MessageFormatter`.

## API Changes

### Breaking change (intentional, shipped as part of a planned major release)

**`Meter.m(String, Object...)` / `MeterContext.ctx(String, String, Object...)`**: same signature, new
semantics. Any existing call using `%` conversions compiles unchanged but silently stops substituting
— the `%` sequence now appears literally in the output:

```java
// Before this change:
meter.m("step %d", 1);        // -> "step 1"
// After this change (same call, no compile error):
meter.m("step %d", 1);        // -> "step %d"   (unless migrated to "step {}")

// Migration:
meter.m("step {}", 1);        // -> "step 1"   (idiomatic {} placeholder)
meter.mf("step %d", 1);       // -> "step 1"   (explicit printf opt-in, Locale.ROOT)
```

**Backward compatibility**: **Not** backward compatible by design — this is the reason it ships in a
major release. Every existing `m(format, args)` / `ctx(name, format, args)` call site using `%`
conversions must be audited and migrated to either `{}` placeholders or the new `mf`/`ctxf` overloads.

## Code Changes

**Production (3 files):**
- `MeterValidator.java` — new `{}`-based `validateMCallArgument`; renamed printf helper
  `validateMfCallArgument` (+ `Locale.ROOT`)
- `Meter.java` — new `{}`-based `m(String, Object...)`; renamed printf overload `mf(String,
  Object...)`
- `MeterContext.java` — new `{}`-based `ctx(String, String, Object...)`; renamed printf overload
  `ctxf(String, String, Object...)` (+ `Locale.ROOT`, `getMessage()` fix)

**Tests (7 files, 19 call sites migrated + new coverage):**
- Incidental `%s`/`%d` usage converted to `{}` under `m`/`ctx` (`MeterLifeCyclePostStartConfigurationTest`,
  `MeterLifeCyclePreStartConfigurationTest`, `MeterLifeCyclePostStopInvalidOperations{Failed,Rejected,Ok}StateTest`)
- Tests exercising printf-specific behavior (illegal format detection, mismatched specifiers) moved to
  `mf`/`ctxf`, with updated `"Meter.mf"` / `"Meter.mf("` log assertions (`MeterLifeCyclePostStartConfigurationTest`,
  `MeterLifeCyclePreStartConfigurationTest`, `MeterValidatorTest`, `MeterContextTest`)
- New tests added for `{}` semantics: `MeterValidatorTest`'s `PlaceholderMessageArgumentsTests`,
  `MeterContextTest`'s `PlaceholderStrings`

**Docs (1 file):** `doc/TDR-0043-slf4j-placeholders-as-primary-meter-message-api.md` (new)

### Post-rebase fixup

Rebasing onto `main` pulled in the just-merged shared null-object for `Meter.getCurrentInstance()`
(`UnknownMeter`, [#96](https://github.com/useful-toys/slf4j-toys/pull/96)), whose entire point is that
every state-mutating `Meter` method is overridden to log `INVALID_TRANSITION` instead of mutating the
shared singleton. That commit had overridden `m(String, Object...)` back when it was still the printf
overload; after the rename in this PR, `UnknownMeter`'s override followed onto the `{}` version,
leaving the **new `mf(String, Object...)` overload unguarded** — calling it on the shared instance would
have silently formatted and stored a description on process-wide shared state, exactly the bug that
null-object was introduced to prevent. Fixed by adding the missing `mf()` override (`ctx()`/`ctxf()`
needed no change: both already route through the overridden `putContext`), with a new
`mfWithFormatLogsInvalidTransition()` test in `MeterUnknownInstanceTest` covering the gap. Separately,
that same merge introduced its own `doc/TDR-0042-...md`, colliding with this PR's TDR number; this PR's
document was renumbered to **TDR-0043**.

Codecov's patch-coverage check subsequently flagged a real gap introduced by that same rebase:
`mf(String, Object...)`'s `validateMPrecondition`-failure branch (calling `mf()` on an already-stopped
`Meter`) had no test, unlike the equivalent `m(String, Object...)` branch. Added
`shouldRejectPrintfDescriptionWithArgsAfterOk()` to close it.

## Test Results

Full suite, both tiers (`mvnw test -P slf4j-2.0,with-logback`), run on this branch after rebasing onto
latest `main`:

- Core tier: **3144** tests — 0 failures, 0 errors
- With-Logback tier: **75** tests — 0 failures, 0 errors
- **BUILD SUCCESS**
- Codecov patch coverage gap (`Meter.java`, `mf()` precondition branch) closed; verified locally against
  `target/site/jacoco/jacoco.xml`

## Examples

```java
// New default: slf4j {} placeholders, locale-free, no Formatter
meter.m("User {} has {} points", user, points);
meter.ctx("status", "Processed {} of {} items", done, total);

// printf still available for cases {} can't express (width, precision, %f)
meter.mf("Total: %.2f", amount);          // deterministic: always "1.50", never "1,50"
meter.ctxf("ratio", "%05.1f%%", percent);
```

## Relevant Documentation

- [TDR-0043: slf4j `{}` Placeholders as the Primary Meter Message API](https://github.com/useful-toys/slf4j-toys/blob/feat/meter-slf4j-message-placeholders/doc/TDR-0043-slf4j-placeholders-as-primary-meter-message-api.md) (new, this PR)
- [TDR-0039](https://github.com/useful-toys/slf4j-toys/blob/main/doc/TDR-0039-accept-scaled-integer-rounding-in-json5-serialization.md) / [TDR-0040](https://github.com/useful-toys/slf4j-toys/blob/main/doc/TDR-0040-locale-independent-readable-messages.md) — the preceding locale-independence work this PR completes
- [TDR-0010](https://github.com/useful-toys/slf4j-toys/blob/main/doc/TDR-0010-simultaneous-support-for-slf4j-1.7-2.0-and-logback-1.2-1.5.md) — why `arrayFormat` (not `basicArrayFormat`) was used

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
