### PR TITLE
Throttle noop-meter misuse reporting and fix its diagnosis message

### DIFF
--- a/doc/TDR-0042-shared-null-object-for-unknown-meter.md
+++ b/doc/TDR-0042-shared-null-object-for-unknown-meter.md
@@ -43,6 +43,30 @@ public static Meter getCurrentInstance() {
 
 **`sub()` becomes absorbing, not delegating.** Previously, `getCurrentInstance().sub("child")` (the implementation of `MeterFactory.getCurrentSubMeter`) built a real, usable `"???/child"` meter even with no active parent — silently manufacturing a meaningless hierarchy entry. `UnknownMeter.sub(...)` now returns `UNKNOWN_INSTANCE` itself and logs the same `INVALID_TRANSITION`, i.e. `UNKNOWN_INSTANCE.sub(x) == UNKNOWN_INSTANCE`. Requesting a sub-operation with no active parent is exactly the same class of misuse as calling `ok()` with no active meter, and is now reported the same way.
 
+### Follow-up: throttling misuse reports against the shared instance
+
+Reporting every misuse unconditionally, as designed above, has a cost concentrated entirely on the shared singleton: a defensive call pattern like `Meter.getCurrentInstance().progress()` in a hot loop with no active meter would log an `ERROR` and allocate a `CallerStackTraceThrowable` (which walks and filters the current stack trace) on *every single call*, flooding the error channel and burning CPU on a cold-path diagnostic that, past the first occurrence, adds no new information.
+
+**Decision:** two package-private hooks on `Meter`, both no-ops for real meters and both overridden by `UnknownMeter`:
+
+```java
+boolean shouldReportInvalidUsage() { return true; }   // real meters: always report
+String invalidUsageDiagnosis() { return null; }        // real meters: keep the caller-supplied message
+```
+
+`MeterValidator.logInvalidTransition`/`logInvalidState` consult `shouldReportInvalidUsage()` (after `getMessageLogger().isErrorEnabled()`, so the throwable allocation is gated by both — real meters pay a trivial `true` check on this already-cold path, never on the hot path of correct usage) and, if the report proceeds, `invalidUsageDiagnosis()` to override the message. `UnknownMeter` implements a time-based rate limit — a static `AtomicLong nextAllowedReportNanos` advanced via a CAS loop on `System.nanoTime()`, and a static `AtomicLong suppressedCount` incremented on every throttled occurrence and drained into the next allowed report's message ("N similar reports suppressed"). The interval is configurable via `MeterConfig.noopReportIntervalMilliseconds` (default 60000 ms; `0` disables throttling; negative disables reporting entirely), following the same system-property convention as every other `MeterConfig` value.
+
+The same `invalidUsageDiagnosis()` override also fixes a latent inaccuracy: `inc()`/`incBy()`/`incTo()`/`progress()`/`path(Object)` are not overridden by `UnknownMeter` (their own preconditions already reject `startTime == 0`, which is permanently true for the singleton), but the message their preconditions produce — *"Meter not yet started, must call start() first"* — is misleading for a meter that was never meant to be started at all. `UnknownMeter.invalidUsageDiagnosis()` replaces it, and any other message routed through these two helpers, with the accurate *"no operation is active on the current thread"*.
+
+#### Alternatives considered for the throttle
+
+- ❌ **Log once, ever.** Simpler, but a single silent misuse pattern early in an application's life would forever suppress evidence of a *different*, later misuse pattern — the throttle needs to keep reporting periodically, not retire permanently after the first occurrence.
+- ❌ **Per-call-site deduplication (keyed by stack trace or caller location).** Would distinguish "many different bugs calling `getCurrentInstance()` unsafely" from "one bug calling it in a loop", which is valuable, but requires capturing and hashing a stack trace (or caller class/method) on every occurrence — reintroducing the exact per-call cost (`CallerStackTraceThrowable` capture) the throttle exists to avoid, just to decide whether to throttle.
+- ❌ **Rely on a backend `DuplicateMessageFilter`** (e.g. Logback's `DuplicateMessageFilter`, or an application-side equivalent). Rejected because it is opt-in, backend-specific configuration external to this library — the whole point of `UnknownMeter` is that the shared instance is *safe by default*, not safe only when the application also configures its logging backend correctly. It also still pays the `CallerStackTraceThrowable` allocation before the backend ever sees the event to decide whether to drop it.
+- ❌ **Downgrade the shared instance's misuse level** (e.g. `WARN` instead of `ERROR`, expecting operators to tune the appLogger threshold down). Rejected: it weakens the diagnostic for every application, including those that never hit the high-frequency pattern this throttle protects against, to work around a problem only some applications have; the throttle solves the actual frequency problem without diluting severity.
+
+The throttle's own runtime state (`nextAllowedReportNanos`, `suppressedCount`) is reset by `MeterConfig.reset()`, alongside the config properties — necessary so that test isolation relying on that reset (e.g. via the existing `@ResetMeterConfig` extension) always observes the first misuse report immediately, regardless of throttle state accumulated by a previous test.
+
 ## Consequences
 
 ### Positive ✅
@@ -55,7 +79,7 @@ public static Meter getCurrentInstance() {
 ### Negative ❌
 
 - **Behavioral change for the sub-meter fallback.** `MeterFactory.getCurrentSubMeter(name)` called with no active parent used to return a distinct, real `"???/name"` meter; it now returns the shared `UNKNOWN_INSTANCE` unchanged (category `"???"`, no operation). Call sites relying on the former fallback's identity or operation name observe different behavior. Verified against the full test suite (2839 tests, both `slf4j-2.0` and `slf4j-2.0,with-logback` profiles); one existing test (`MeterFactoryTest.shouldCreateSubMeterFromFallbackWhenNoCurrentMeterIsStarted`) was updated to assert the new absorbing behavior.
-- **Larger, harder-to-forget override surface.** Every future state-mutating method added to `Meter` must be remembered and added to `UnknownMeter`'s overrides, or it silently mutates the shared singleton again. This risk is bounded by the fact that all current mutators already follow the `if (!MeterValidator.validateXxx(this)) return this;` guard-clause pattern, making the override list mechanically derivable by inspection, and by `MeterUnknownInstanceTest`, which exercises every currently known mutator against the singleton.
+- **Larger, harder-to-forget override surface.** Every future state-mutating method added to `Meter` must be remembered and added to `UnknownMeter`'s overrides, or it silently mutates the shared singleton again. This risk is bounded by the fact that all current mutators already follow the `if (!MeterValidator.validateXxx(this)) return this;` guard-clause pattern, making the override list mechanically derivable by inspection, and by `MeterUnknownInstanceTest`, which exercises every currently known mutator against the singleton. `MeterUnknownInstanceOverrideInvariantTest` closes the remaining gap for *future* additions: it reflectively enumerates every public, `Meter`/`void`-returning method declared on `Meter` and fails loudly if that set drifts from a hand-maintained invoker map, rather than silently missing a newly added method the way a purely hand-listed test would.
 
 ### Neutral ⚖️
 
@@ -90,8 +114,12 @@ public static Meter getCurrentInstance() {
 
 ## Implementation
 
-- [src/main/java/org/usefultoys/slf4j/meter/Meter.java](../src/main/java/org/usefultoys/slf4j/meter/Meter.java) — `UNKNOWN_INSTANCE` field, `getCurrentInstance()` miss path, and the nested `UnknownMeter` class with its overrides.
+- [src/main/java/org/usefultoys/slf4j/meter/Meter.java](../src/main/java/org/usefultoys/slf4j/meter/Meter.java) — `UNKNOWN_INSTANCE` field, `getCurrentInstance()` miss path, the nested `UnknownMeter` class with its overrides, the `shouldReportInvalidUsage()`/`invalidUsageDiagnosis()` hooks, and `UnknownMeter`'s throttle fields/overrides.
+- [src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java](../src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java) — `logInvalidTransition`/`logInvalidState` gate the `CallerStackTraceThrowable` allocation on `isErrorEnabled()` and `shouldReportInvalidUsage()`, and consult `invalidUsageDiagnosis()` to override the message.
+- [src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java](../src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java) — `noopReportIntervalMilliseconds` property; `reset()` also resets the throttle's runtime state via `Meter.resetNoopReportThrottle()`.
 - [src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java](../src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java) — asserts single-instance identity (repeated calls and across threads), the unknown category, and that every overridden mutator logs `INVALID_TRANSITION` without changing observable state.
+- [src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceOverrideInvariantTest.java](../src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceOverrideInvariantTest.java) — reflective safety net: enumerates every qualifying method on `Meter` and cross-checks it against a hand-maintained invoker map, then asserts each one leaves `UNKNOWN_INSTANCE`'s observable state unchanged.
+- [src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceThrottleTest.java](../src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceThrottleTest.java) — throttle behavior: immediate first report, suppression within the interval, suppressed-count embedding after the interval elapses, `0`/negative interval edge cases, real meters never throttled, no throwable allocated when `ERROR` is disabled.
 - [src/test/java/org/usefultoys/slf4j/meter/MeterFactoryTest.java](../src/test/java/org/usefultoys/slf4j/meter/MeterFactoryTest.java) — `shouldCreateSubMeterFromFallbackWhenNoCurrentMeterIsStarted` updated for the absorbing `sub()` behavior.
 
 ## References

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -654,6 +654,49 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
         return ref == null || ref.get() != this;
     }
 
+    /**
+     * Whether a misuse report ({@code INVALID_ARGUMENT}/{@code INVALID_STATE}/{@code INVALID_TRANSITION})
+     * should actually be logged for this `Meter` right now.
+     * <p>
+     * Real meters always report every misuse: this hook is only consulted on the cold misuse-reporting
+     * path in {@link MeterValidator}, never on the hot path of a correctly used meter, so returning
+     * {@code true} unconditionally costs nothing. {@link UnknownMeter} overrides this to throttle
+     * high-frequency misuse against the shared, process-wide null-object (see TDR-0042), so that a
+     * defensive call pattern like {@code Meter.getCurrentInstance().progress()} in a hot loop cannot flood
+     * the error channel or pay a stack-trace capture on every single call.
+     *
+     * @return {@code true} if this misuse occurrence should be reported now.
+     */
+    boolean shouldReportInvalidUsage() {
+        return true;
+    }
+
+    /**
+     * Diagnosis message that overrides the caller-supplied message when a misuse report is about this
+     * `Meter`'s own identity (e.g. being the shared unknown-meter null-object) rather than a specific
+     * lifecycle-state mismatch. Real meters return {@code null}, leaving the caller-supplied message
+     * intact.
+     * <p>
+     * Called only when {@link #shouldReportInvalidUsage()} allowed the report, so an override may also
+     * use it to embed a suppressed-report count accumulated since the previous allowed report.
+     *
+     * @return the replacement diagnosis message, or {@code null} to keep the caller-supplied message.
+     */
+    String invalidUsageDiagnosis() {
+        return null;
+    }
+
+    /**
+     * Resets the shared unknown-meter misuse-report throttle to its initial, unthrottled state: no
+     * suppressed reports, next report allowed immediately. Package-private: called from
+     * {@link MeterConfig#reset()} so tests relying on that reset always observe the throttle in a clean
+     * state, regardless of activity accumulated by a previous test.
+     */
+    static void resetNoopReportThrottle() {
+        UnknownMeter.nextAllowedReportNanos.set(0L);
+        UnknownMeter.suppressedCount.set(0L);
+    }
+
     public Meter ok() {
         commonOk(null);
         return this;
@@ -853,18 +896,74 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * any number of threads at once. {@code inc()}, {@code incBy()}, {@code incTo()} and
      * {@code progress()} need no override: their preconditions already reject a never-started
      * meter, and this instance can never be started. See TDR-0042.
+     * <p>
+     * Overrides {@link #shouldReportInvalidUsage()} to throttle misuse reports (at most one per
+     * {@link MeterConfig#noopReportIntervalMilliseconds}) and {@link #invalidUsageDiagnosis()} to
+     * report the accurate diagnosis for this shared instance — "no operation is active on the current
+     * thread" rather than the "not yet started" wording a real meter's precondition would otherwise
+     * produce for {@code inc()}/{@code incBy()}/{@code incTo()}/{@code progress()}/{@code path(Object)} —
+     * with the count of reports suppressed since the previous one, if any.
      */
     private static final class UnknownMeter extends Meter {
 
         private static final long serialVersionUID = 1L;
+
+        /** Base diagnosis message for every misuse reported against the shared unknown-meter instance. */
+        private static final String DIAGNOSIS = "no operation is active on the current thread";
+
+        /** Next point in time ({@link System#nanoTime()}) at which a misuse report may be logged again. */
+        private static final AtomicLong nextAllowedReportNanos = new AtomicLong(0L);
+        /** Count of misuse occurrences skipped since the last allowed report. */
+        private static final AtomicLong suppressedCount = new AtomicLong(0L);
 
         UnknownMeter() {
             super(LoggerFactory.getLogger(UNKNOWN_LOGGER_NAME));
         }
 
         private Meter denied() {
-            MeterValidator.logInvalidTransition(this, "no operation is active on the current thread");
+            MeterValidator.logInvalidTransition(this, DIAGNOSIS);
             return this;
+        }
+
+        /**
+         * Throttles misuse reports against the shared instance to at most one per
+         * {@link MeterConfig#noopReportIntervalMilliseconds}, using a CAS loop on a shared "next allowed"
+         * timestamp so concurrent callers from multiple threads never both win the same window. {@code 0}
+         * disables throttling (report every occurrence); a negative interval disables reporting entirely.
+         */
+        @Override
+        boolean shouldReportInvalidUsage() {
+            final long intervalMillis = MeterConfig.noopReportIntervalMilliseconds;
+            if (intervalMillis < 0) {
+                suppressedCount.incrementAndGet();
+                return false;
+            }
+            if (intervalMillis == 0) {
+                return true;
+            }
+            final long intervalNanos = intervalMillis * 1_000_000L;
+            final long now = System.nanoTime();
+            long current = nextAllowedReportNanos.get();
+            while (now - current >= 0) {
+                if (nextAllowedReportNanos.compareAndSet(current, now + intervalNanos)) {
+                    return true;
+                }
+                current = nextAllowedReportNanos.get();
+            }
+            suppressedCount.incrementAndGet();
+            return false;
+        }
+
+        /**
+         * Replaces whatever message the caller supplied with the accurate diagnosis for this shared
+         * instance, embedding the count of reports suppressed since the last allowed one, if any. Called
+         * only when {@link #shouldReportInvalidUsage()} allowed the report, so reading-and-resetting the
+         * counter here is safe: it only ever fires once per actually-emitted report.
+         */
+        @Override
+        String invalidUsageDiagnosis() {
+            final long suppressed = suppressedCount.getAndSet(0L);
+            return suppressed > 0 ? DIAGNOSIS + " (" + suppressed + " similar reports suppressed)" : DIAGNOSIS;
         }
 
         @Override

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -927,9 +927,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
 
         /**
          * Throttles misuse reports against the shared instance to at most one per
-         * {@link MeterConfig#noopReportIntervalMilliseconds}, using a CAS loop on a shared "next allowed"
-         * timestamp so concurrent callers from multiple threads never both win the same window. {@code 0}
-         * disables throttling (report every occurrence); a negative interval disables reporting entirely.
+         * {@link MeterConfig#noopReportIntervalMilliseconds}. {@code 0} disables throttling (report every
+         * occurrence); a negative interval disables reporting entirely.
          */
         @Override
         boolean shouldReportInvalidUsage() {
@@ -938,10 +937,21 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 suppressedCount.incrementAndGet();
                 return false;
             }
-            if (intervalMillis == 0) {
+            if (intervalMillis == 0 || tryClaimReportWindow(intervalMillis * 1_000_000L)) {
                 return true;
             }
-            final long intervalNanos = intervalMillis * 1_000_000L;
+            suppressedCount.incrementAndGet();
+            return false;
+        }
+
+        /**
+         * Attempts to claim the next report window via a CAS loop on the shared "next allowed" timestamp,
+         * so concurrent callers from multiple threads never both win the same window.
+         *
+         * @param intervalNanos the throttle interval, in nanoseconds.
+         * @return {@code true} if this call claimed the window and may report now.
+         */
+        private static boolean tryClaimReportWindow(final long intervalNanos) {
             final long now = System.nanoTime();
             long current = nextAllowedReportNanos.get();
             while (now - current >= 0) {
@@ -950,7 +960,6 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 }
                 current = nextAllowedReportNanos.get();
             }
-            suppressedCount.incrementAndGet();
             return false;
         }
 

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -64,6 +64,8 @@ public class MeterConfig {
     public final String PROP_PRINT_STATUS = "slf4jtoys.meter.print.status";
     /** System property key for enabling/disabling the forgotten-meter leak detector. */
     public final String PROP_DETECT_LEAKS = "slf4jtoys.meter.detect.leaks";
+    /** System property key for the shared unknown-meter misuse-report throttle interval. */
+    public final String PROP_NOOP_REPORT_INTERVAL = "slf4jtoys.meter.noop.report.interval";
 
     static {
         init();
@@ -135,6 +137,25 @@ public class MeterConfig {
      * deregister or discard already-pending reports.
      */
     public boolean detectLeaks;
+
+    /**
+     * Minimum time interval (in milliseconds) between consecutive misuse reports logged by the shared
+     * unknown-meter null-object returned by {@link Meter#getCurrentInstance()} when no meter is active on
+     * the current thread (see TDR-0042).
+     * <p>
+     * Defensive call patterns like {@code Meter.getCurrentInstance().progress()} in a hot loop would
+     * otherwise log an {@code ERROR} and capture a stack trace on every single call. Reports are throttled
+     * to at most one per interval; when a throttled report is finally emitted, its message includes the
+     * count of similar reports suppressed since the previous one.
+     * <p>
+     * {@code 0} disables throttling: every occurrence is reported. A negative value disables reporting
+     * entirely: no misuse against the shared instance is ever logged.
+     * <p>
+     * Value is read from system property {@code slf4jtoys.meter.noop.report.interval}, defaulting to
+     * {@code 60000} (1 minute). The value can be suffixed with {@code ms}, {@code s}, {@code m}, or
+     * {@code h}. Can be assigned a new value at runtime.
+     */
+    public long noopReportIntervalMilliseconds;
 
     /**
      * A prefix added to the logger name used for machine-parsable data messages.
@@ -216,6 +237,7 @@ public class MeterConfig {
         printLoad = ConfigParser.getProperty(PROP_PRINT_LOAD, false);
         printMemory = ConfigParser.getProperty(PROP_PRINT_MEMORY, false);
         detectLeaks = ConfigParser.getProperty(PROP_DETECT_LEAKS, true);
+        noopReportIntervalMilliseconds = ConfigParser.getMillisecondsProperty(PROP_NOOP_REPORT_INTERVAL, 60000L);
         dataPrefix = ConfigParser.getProperty(PROP_DATA_PREFIX, "");
         dataSuffix = ConfigParser.getProperty(PROP_DATA_SUFFIX, "");
         messagePrefix = ConfigParser.getProperty(PROP_MESSAGE_PREFIX, "");
@@ -225,6 +247,11 @@ public class MeterConfig {
     /**
      * Resets all configuration properties to their default values.
      * This method is useful for testing purposes or when reinitializing the configuration.
+     * <p>
+     * Also resets the shared unknown-meter misuse-report throttle's runtime state (next-allowed-report
+     * timestamp and suppressed-report count) back to its initial, unthrottled state, so tests relying on
+     * this reset (e.g. via {@code @ResetMeterConfig}) always observe the first misuse report immediately,
+     * regardless of throttle state accumulated by a previous test.
      */
     public void reset() {
         System.clearProperty(PROP_PROGRESS_PERIOD);
@@ -234,10 +261,12 @@ public class MeterConfig {
         System.clearProperty(PROP_PRINT_LOAD);
         System.clearProperty(PROP_PRINT_MEMORY);
         System.clearProperty(PROP_DETECT_LEAKS);
+        System.clearProperty(PROP_NOOP_REPORT_INTERVAL);
         System.clearProperty(PROP_DATA_PREFIX);
         System.clearProperty(PROP_DATA_SUFFIX);
         System.clearProperty(PROP_MESSAGE_PREFIX);
         System.clearProperty(PROP_MESSAGE_SUFFIX);
         init();
+        Meter.resetNoopReportThrottle();
     }
 }

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterValidator.java
@@ -351,17 +351,42 @@ public class MeterValidator {
 
     /**
      * Logs an illegal precondition for a Meter operation.
+     * <p>
+     * Gated on {@link org.slf4j.Logger#isErrorEnabled()} and {@link Meter#shouldReportInvalidUsage()},
+     * checked in that order, before allocating the {@link CallerStackTraceThrowable}: real meters always
+     * report (the hook is a trivial {@code true}, only reached on this cold misuse path, so the hot path
+     * of a correctly used {@code Meter} pays nothing extra), while the shared unknown-meter null-object
+     * throttles high-frequency misuse instead of flooding the error channel and paying a stack-trace
+     * capture per call. See TDR-0042.
+     *
      * @param meter   The Meter instance with the illegal precondition.
      * @param message A descriptive message about the illegal precondition.
      */
     void logInvalidState(final Meter meter, final String message) {
+        if (!meter.getMessageLogger().isErrorEnabled() || !meter.shouldReportInvalidUsage()) {
+            return;
+        }
         final CallerStackTraceThrowable throwable = new CallerStackTraceThrowable();
-        meter.getMessageLogger().error(Markers.INVALID_STATE, "Meter.{} - {}; id={}", throwable.getApiMethodName(), message, meter.getFullID(), throwable);
+        final String diagnosis = meter.invalidUsageDiagnosis();
+        meter.getMessageLogger().error(Markers.INVALID_STATE, "Meter.{} - {}; id={}", throwable.getApiMethodName(), diagnosis != null ? diagnosis : message, meter.getFullID(), throwable);
     }
 
+    /**
+     * Logs an illegal state transition for a Meter operation.
+     * <p>
+     * Gated the same way as {@link #logInvalidState(Meter, String)}: see its Javadoc for the ordering
+     * rationale and the throttle behavior of the shared unknown-meter null-object.
+     *
+     * @param meter   The Meter instance with the illegal transition.
+     * @param message A descriptive message about the illegal transition.
+     */
     void logInvalidTransition(final Meter meter, final String message) {
+        if (!meter.getMessageLogger().isErrorEnabled() || !meter.shouldReportInvalidUsage()) {
+            return;
+        }
         final CallerStackTraceThrowable throwable = new CallerStackTraceThrowable();
-        meter.getMessageLogger().error(Markers.INVALID_TRANSITION, "Meter.{} - {}; id={}", throwable.getApiMethodName(), message, meter.getFullID(), throwable);
+        final String diagnosis = meter.invalidUsageDiagnosis();
+        meter.getMessageLogger().error(Markers.INVALID_TRANSITION, "Meter.{} - {}; id={}", throwable.getApiMethodName(), diagnosis != null ? diagnosis : message, meter.getFullID(), throwable);
     }
 
     /**

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceOverrideInvariantTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceOverrideInvariantTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.usefultoys.test.ResetMeterConfig;
+import org.usefultoys.test.ValidateCleanMeter;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Guards the invariant documented on {@code UnknownMeter} (see TDR-0042): every public, state-mutating
+ * method declared on {@link Meter} must either be overridden by {@code UnknownMeter} to deny the call, or
+ * be provably safe as-is because its own precondition already rejects a never-started meter.
+ * <p>
+ * This invariant is currently unenforced by the compiler: a new method added to {@code Meter} that writes
+ * a field directly (as {@link Meter#mf(String, Object...)} does on branch
+ * {@code feat/meter-slf4j-message-placeholders}, which writes {@code description} while its only guard,
+ * {@code validateMPrecondition}, checks {@code stopTime} rather than identity) would silently start
+ * mutating the shared, process-wide {@code UNKNOWN_INSTANCE} the moment both branches are merged, unless
+ * {@code UnknownMeter} is updated to override it too.
+ * <p>
+ * Rather than hand-listing "the methods we remembered to check" (which cannot catch a method nobody
+ * remembered to add), this test reflectively enumerates every qualifying method on {@link Meter} and
+ * cross-checks it against a hand-maintained invoker map: a mismatch fails loudly, forcing whoever adds a
+ * new state-mutating method to consciously add an invoker here (and, if needed, an {@code UnknownMeter}
+ * override) rather than discovering the gap later as silent shared-state corruption.
+ *
+ * @author Daniel Felix Ferber
+ */
+@ResetMeterConfig
+@ValidateCleanMeter
+@DisplayName("UnknownMeter override invariant (reflective safety net)")
+class MeterUnknownInstanceOverrideInvariantTest {
+
+    /**
+     * One invoker per qualifying method, keyed by the same signature format produced by
+     * {@link #signatureOf(Method)}, so {@link #everyQualifyingMethodHasAnInvoker()} can assert the two
+     * sets are identical.
+     */
+    private static final Map<String, Function<Meter, Object>> INVOKERS = new LinkedHashMap<>();
+
+    static {
+        INVOKERS.put("sub(java.lang.String)", m -> m.sub("child"));
+        INVOKERS.put("m(java.lang.String)", m -> m.m("message"));
+        INVOKERS.put("m(java.lang.String,[Ljava.lang.Object;)", m -> m.m("message {}", 1));
+        INVOKERS.put("limitMilliseconds(long)", m -> m.limitMilliseconds(1000L));
+        INVOKERS.put("iterations(long)", m -> m.iterations(10L));
+        INVOKERS.put("putContext(java.lang.String,java.lang.Object)", m -> {
+            m.putContext("key", "value");
+            return null;
+        });
+        INVOKERS.put("putContext(java.lang.String)", m -> {
+            m.putContext("flag");
+            return null;
+        });
+        INVOKERS.put("start()", Meter::start);
+        INVOKERS.put("inc()", Meter::inc);
+        INVOKERS.put("incBy(long)", m -> m.incBy(1L));
+        INVOKERS.put("incTo(long)", m -> m.incTo(1L));
+        INVOKERS.put("progress()", Meter::progress);
+        INVOKERS.put("path(java.lang.Object)", m -> m.path("somePath"));
+        INVOKERS.put("ok()", Meter::ok);
+        INVOKERS.put("ok(java.lang.Object)", m -> m.ok("somePath"));
+        INVOKERS.put("success()", Meter::success);
+        INVOKERS.put("success(java.lang.Object)", m -> m.success("somePath"));
+        INVOKERS.put("reject(java.lang.Object)", m -> m.reject("someCause"));
+        INVOKERS.put("fail(java.lang.Object)", m -> m.fail("someCause"));
+        INVOKERS.put("close()", m -> {
+            m.close();
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("every public, non-static, Meter/void-returning method declared on Meter has a registered invoker")
+    void everyQualifyingMethodHasAnInvoker() {
+        final Set<String> declared = qualifyingMethodSignatures();
+        assertEquals(declared, INVOKERS.keySet(),
+                "Meter gained or lost a state-mutating method not reflected in this test's INVOKERS map. "
+                        + "Add (or remove) an invoker here, and make sure UnknownMeter overrides any new "
+                        + "method with denied() unless its own precondition already rejects a never-started "
+                        + "meter (see TDR-0042 and TDR-0041).");
+    }
+
+    @Test
+    @DisplayName("every registered method leaves UNKNOWN_INSTANCE's observable state unchanged")
+    void everyRegisteredMethodIsANoOpOnUnknownInstance() {
+        for (final Map.Entry<String, Function<Meter, Object>> entry : INVOKERS.entrySet()) {
+            final String signature = entry.getKey();
+            final Meter unknown = Meter.getCurrentInstance();
+            final Snapshot before = Snapshot.of(unknown);
+
+            entry.getValue().apply(unknown);
+
+            final Snapshot after = Snapshot.of(unknown);
+            assertEquals(before, after, () -> signature + " mutated observable state of the shared UNKNOWN_INSTANCE");
+            assertSame(unknown, Meter.getCurrentInstance(),
+                    signature + " must not push a new current instance onto the thread-local stack");
+        }
+    }
+
+    /**
+     * Enumerates every method declared directly on {@link Meter} (not inherited from {@code MeterData} or
+     * the {@code MeterContext}/{@code MeterExecutor} interfaces) that is public, non-static, and returns
+     * either {@code Meter} (the fluent chaining idiom used throughout this API) or {@code void} — i.e. the
+     * exact shape every state-mutating operation in this class follows.
+     */
+    private static Set<String> qualifyingMethodSignatures() {
+        final Set<String> result = new TreeSet<>();
+        for (final Method method : Meter.class.getDeclaredMethods()) {
+            if (method.isBridge() || method.isSynthetic()) {
+                continue;
+            }
+            final int modifiers = method.getModifiers();
+            if (!Modifier.isPublic(modifiers) || Modifier.isStatic(modifiers)) {
+                continue;
+            }
+            final Class<?> returnType = method.getReturnType();
+            if (returnType != Meter.class && returnType != void.class) {
+                continue;
+            }
+            result.add(signatureOf(method));
+        }
+        return result;
+    }
+
+    private static String signatureOf(final Method method) {
+        final StringBuilder sb = new StringBuilder(method.getName()).append('(');
+        final Class<?>[] params = method.getParameterTypes();
+        for (int i = 0; i < params.length; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(params[i].getName());
+        }
+        return sb.append(')').toString();
+    }
+
+    /** Immutable capture of every field the task requires to remain unchanged, for before/after comparison. */
+    private static final class Snapshot {
+        private final String description;
+        private final Map<String, String> context;
+        private final long startTime;
+        private final long stopTime;
+        private final long currentIteration;
+        private final long expectedIterations;
+        private final long timeLimit;
+        private final String okPath;
+        private final String rejectPath;
+        private final String failPath;
+        private final String failMessage;
+
+        private Snapshot(final Meter m) {
+            description = m.getDescription();
+            context = new HashMap<>(m.getContext());
+            startTime = m.getStartTime();
+            stopTime = m.getStopTime();
+            currentIteration = m.getCurrentIteration();
+            expectedIterations = m.getExpectedIterations();
+            timeLimit = m.getTimeLimit();
+            okPath = m.getOkPath();
+            rejectPath = m.getRejectPath();
+            failPath = m.getFailPath();
+            failMessage = m.getFailMessage();
+        }
+
+        static Snapshot of(final Meter m) {
+            return new Snapshot(m);
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Snapshot)) {
+                return false;
+            }
+            final Snapshot other = (Snapshot) o;
+            return startTime == other.startTime
+                    && stopTime == other.stopTime
+                    && currentIteration == other.currentIteration
+                    && expectedIterations == other.expectedIterations
+                    && timeLimit == other.timeLimit
+                    && java.util.Objects.equals(description, other.description)
+                    && java.util.Objects.equals(context, other.context)
+                    && java.util.Objects.equals(okPath, other.okPath)
+                    && java.util.Objects.equals(rejectPath, other.rejectPath)
+                    && java.util.Objects.equals(failPath, other.failPath)
+                    && java.util.Objects.equals(failMessage, other.failMessage);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(description, context, startTime, stopTime, currentIteration,
+                    expectedIterations, timeLimit, okPath, rejectPath, failPath, failMessage);
+        }
+
+        @Override
+        public String toString() {
+            return "Snapshot{description=" + description + ", context=" + context + ", startTime=" + startTime
+                    + ", stopTime=" + stopTime + ", currentIteration=" + currentIteration
+                    + ", expectedIterations=" + expectedIterations + ", timeLimit=" + timeLimit
+                    + ", okPath=" + okPath + ", rejectPath=" + rejectPath + ", failPath=" + failPath
+                    + ", failMessage=" + failMessage + '}';
+        }
+    }
+}

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceThrottleTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceThrottleTest.java
@@ -151,7 +151,7 @@ class MeterUnknownInstanceThrottleTest {
                    window as possible, maximizing the chance that multiple threads observe the same stale
                    "next allowed" timestamp and must retry the CAS loop against each other. */
                 while (!start.get()) {
-                    Thread.onSpinWait();
+                    Thread.yield();
                 }
                 if (unknown.shouldReportInvalidUsage()) {
                     claimedCount.incrementAndGet();
@@ -161,7 +161,7 @@ class MeterUnknownInstanceThrottleTest {
         }
 
         while (readyCount.get() < threadCount) {
-            Thread.onSpinWait();
+            Thread.yield();
         }
         start.set(true);
         for (final Thread thread : threads) {

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceThrottleTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceThrottleTest.java
@@ -27,6 +27,10 @@ import org.usefultoys.slf4jtestmock.AssertLogger;
 import org.usefultoys.test.ResetMeterConfig;
 import org.usefultoys.test.ValidateCleanMeter;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.slf4j.impl.MockLoggerEvent.Level.ERROR;
 import static org.usefultoys.slf4j.meter.Markers.INVALID_STATE;
@@ -116,6 +120,59 @@ class MeterUnknownInstanceThrottleTest {
     }
 
     @Test
+    @DisplayName("misuse routed through logInvalidState (inc/incBy/incTo/progress/path) is also throttled "
+            + "and uses the corrected diagnosis, not the misleading \"not yet started\" message")
+    void misuseViaLogInvalidStateIsThrottledAndUsesCorrectDiagnosis() {
+        MeterConfig.noopReportIntervalMilliseconds = 60_000L;
+        final Meter unknown = Meter.getCurrentInstance();
+
+        unknown.inc(); // not overridden by UnknownMeter; rejected by validateIncPrecondition -> logInvalidState
+        unknown.inc(); // suppressed
+        unknown.inc(); // suppressed
+
+        AssertLogger.assertEventCount(unknownLogger, 1);
+        AssertLogger.assertEvent(unknownLogger, 0, ERROR, INVALID_STATE, "no operation is active on the current thread");
+    }
+
+    @Test
+    @DisplayName("concurrent misuse: exactly one thread claims the report window, the rest retry the CAS loop")
+    void concurrentMisuseOnlyOneThreadClaimsTheWindow() throws InterruptedException {
+        MeterConfig.noopReportIntervalMilliseconds = 60_000L;
+        final int threadCount = 64;
+        final AtomicInteger readyCount = new AtomicInteger(0);
+        final AtomicBoolean start = new AtomicBoolean(false);
+        final AtomicInteger claimedCount = new AtomicInteger(0);
+        final Thread[] threads = new Thread[threadCount];
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(() -> {
+                final Meter unknown = Meter.getCurrentInstance();
+                readyCount.incrementAndGet();
+                /* Busy-spin on a plain flag (no park/unpark) to release all threads within as tight a
+                   window as possible, maximizing the chance that multiple threads observe the same stale
+                   "next allowed" timestamp and must retry the CAS loop against each other. */
+                while (!start.get()) {
+                    Thread.onSpinWait();
+                }
+                if (unknown.shouldReportInvalidUsage()) {
+                    claimedCount.incrementAndGet();
+                }
+            });
+            threads[i].start();
+        }
+
+        while (readyCount.get() < threadCount) {
+            Thread.onSpinWait();
+        }
+        start.set(true);
+        for (final Thread thread : threads) {
+            thread.join();
+        }
+
+        assertEquals(1, claimedCount.get(),
+                "exactly one of " + threadCount + " concurrent misuse occurrences should claim the report window");
+    }
+
+    @Test
     @DisplayName("real (non-singleton) meters are never throttled")
     void realMetersAreNeverThrottled() {
         /* Long enough to throttle the singleton, to prove it has no effect on a real Meter */
@@ -138,11 +195,12 @@ class MeterUnknownInstanceThrottleTest {
     }
 
     @Test
-    @DisplayName("no CallerStackTraceThrowable is allocated when ERROR is disabled")
+    @DisplayName("no CallerStackTraceThrowable is allocated when ERROR is disabled, via logInvalidTransition or logInvalidState")
     void noThrowableAllocatedWhenErrorDisabled() {
         unknownLogger.setErrorEnabled(false);
         try (MockedConstruction<CallerStackTraceThrowable> mocked = Mockito.mockConstruction(CallerStackTraceThrowable.class)) {
-            Meter.getCurrentInstance().start();
+            Meter.getCurrentInstance().start(); // routes through logInvalidTransition
+            Meter.getCurrentInstance().inc();   // routes through logInvalidState
 
             assertTrue(mocked.constructed().isEmpty(),
                     "no CallerStackTraceThrowable should be allocated when ERROR is disabled");

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceThrottleTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceThrottleTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Daniel Felix Ferber
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.usefultoys.slf4j.meter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.slf4j.impl.MockLogger;
+import org.usefultoys.slf4j.CallerStackTraceThrowable;
+import org.usefultoys.slf4j.LoggerFactory;
+import org.usefultoys.slf4jtestmock.AssertLogger;
+import org.usefultoys.test.ResetMeterConfig;
+import org.usefultoys.test.ValidateCleanMeter;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.slf4j.impl.MockLoggerEvent.Level.ERROR;
+import static org.usefultoys.slf4j.meter.Markers.INVALID_STATE;
+import static org.usefultoys.slf4j.meter.Markers.INVALID_TRANSITION;
+
+/**
+ * Verifies the misuse-report throttle on the shared unknown-meter null-object (see TDR-0042): a
+ * defensive call pattern like {@code Meter.getCurrentInstance().progress()} in a hot loop must not flood
+ * the error channel or pay a stack-trace capture on every single call.
+ *
+ * @author Daniel Felix Ferber
+ */
+@ResetMeterConfig
+@ValidateCleanMeter
+@DisplayName("Shared unknown-meter misuse-report throttle")
+class MeterUnknownInstanceThrottleTest {
+
+    private MockLogger unknownLogger;
+
+    @BeforeEach
+    void resolveUnknownLogger() {
+        unknownLogger = (MockLogger) Meter.getCurrentInstance().getMessageLogger();
+        unknownLogger.clearEvents();
+    }
+
+    @Test
+    @DisplayName("first misuse after reset reports immediately")
+    void firstMisuseReportsImmediately() {
+        Meter.getCurrentInstance().start();
+
+        AssertLogger.assertEvent(unknownLogger, 0, ERROR, INVALID_TRANSITION);
+        AssertLogger.assertEventCount(unknownLogger, 1);
+    }
+
+    @Test
+    @DisplayName("subsequent misuse within the interval is suppressed")
+    void subsequentMisuseWithinIntervalIsSuppressed() {
+        MeterConfig.noopReportIntervalMilliseconds = 60_000L;
+        final Meter unknown = Meter.getCurrentInstance();
+
+        unknown.start(); // reports immediately
+        unknown.start(); // suppressed
+        unknown.start(); // suppressed
+
+        AssertLogger.assertEventCount(unknownLogger, 1);
+    }
+
+    @Test
+    @DisplayName("a report after the interval elapses carries the suppressed count")
+    void reportAfterIntervalCarriesSuppressedCount() throws InterruptedException {
+        MeterConfig.noopReportIntervalMilliseconds = 20L;
+        final Meter unknown = Meter.getCurrentInstance();
+
+        unknown.start(); // reports immediately
+        unknown.start(); // suppressed (1)
+        unknown.start(); // suppressed (2)
+        Thread.sleep(60); // cross the interval
+        unknown.start(); // reports again, with the suppressed count embedded
+
+        AssertLogger.assertEventCount(unknownLogger, 2);
+        AssertLogger.assertEvent(unknownLogger, 1, ERROR, INVALID_TRANSITION, "2 similar reports suppressed");
+    }
+
+    @Test
+    @DisplayName("interval 0 reports every occurrence")
+    void intervalZeroReportsEveryOccurrence() {
+        MeterConfig.noopReportIntervalMilliseconds = 0L;
+        final Meter unknown = Meter.getCurrentInstance();
+
+        unknown.start();
+        unknown.start();
+        unknown.start();
+
+        AssertLogger.assertEventCount(unknownLogger, 3);
+    }
+
+    @Test
+    @DisplayName("negative interval reports nothing")
+    void negativeIntervalReportsNothing() {
+        MeterConfig.noopReportIntervalMilliseconds = -1L;
+        final Meter unknown = Meter.getCurrentInstance();
+
+        unknown.start();
+        unknown.start();
+
+        AssertLogger.assertEventCount(unknownLogger, 0);
+    }
+
+    @Test
+    @DisplayName("real (non-singleton) meters are never throttled")
+    void realMetersAreNeverThrottled() {
+        /* Long enough to throttle the singleton, to prove it has no effect on a real Meter */
+        MeterConfig.noopReportIntervalMilliseconds = 60_000L;
+        final MockLogger logger = (MockLogger) LoggerFactory.getLogger("realMeterThrottleTest");
+        logger.clearEvents();
+        final Meter meter = new Meter(logger).start();
+        meter.ok();
+        logger.clearEvents(); // discard the legitimate start()/ok() events; only misuse matters below
+
+        /* Every call below hits the same "already stopped" branch of validateMPrecondition */
+        meter.m("first misuse");
+        meter.m("second misuse");
+        meter.m("third misuse");
+
+        AssertLogger.assertEventCount(logger, 3);
+        AssertLogger.assertEvent(logger, 0, ERROR, INVALID_STATE);
+        AssertLogger.assertEvent(logger, 1, ERROR, INVALID_STATE);
+        AssertLogger.assertEvent(logger, 2, ERROR, INVALID_STATE);
+    }
+
+    @Test
+    @DisplayName("no CallerStackTraceThrowable is allocated when ERROR is disabled")
+    void noThrowableAllocatedWhenErrorDisabled() {
+        unknownLogger.setErrorEnabled(false);
+        try (MockedConstruction<CallerStackTraceThrowable> mocked = Mockito.mockConstruction(CallerStackTraceThrowable.class)) {
+            Meter.getCurrentInstance().start();
+
+            assertTrue(mocked.constructed().isEmpty(),
+                    "no CallerStackTraceThrowable should be allocated when ERROR is disabled");
+        } finally {
+            unknownLogger.setErrorEnabled(true);
+        }
+    }
+}

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterValidatorTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterValidatorTest.java
@@ -80,6 +80,10 @@ public class MeterValidatorTest {
         MockitoAnnotations.openMocks(this);
         lenient().when(meter.getMessageLogger()).thenReturn(logger);
         lenient().when(meter.getFullID()).thenReturn("test-id");
+        /* Match real Meter's default: always report misuse. Without this stub, the mock's unstubbed
+           boolean method returns false, silently suppressing every logInvalidState/logInvalidTransition
+           call under test (see MeterValidator.shouldReportInvalidUsage() gate, TDR-0042). */
+        lenient().when(meter.shouldReportInvalidUsage()).thenReturn(true);
     }
 
     @Nested


### PR DESCRIPTION
## Context

PR #96 replaced the per-call throwaway dummy `Meter` returned by `getCurrentInstance()` with a shared, process-wide null-object (`UNKNOWN_INSTANCE`, see TDR-0042): every misuse call on it now logs an `INVALID_TRANSITION`/`INVALID_STATE` instead of silently mutating shared state. This is a follow-up on the same feature, closing gaps identified after that merge.

## Problem

Every misuse call on `UNKNOWN_INSTANCE` allocates a `CallerStackTraceThrowable` (which walks and filters the current stack trace) and logs an `ERROR`, unconditionally:

```java
Meter.getCurrentInstance().progress();   // in a hot loop, no active meter ❌
// -> ERROR + stack-trace capture on every single call, forever
```

A defensive call pattern like this — reading `getCurrentInstance()` on every request to opportunistically attach context — would flood the error channel and burn CPU on a diagnostic that, past the first occurrence, adds no new information.

Separately, `inc()`/`incBy()`/`incTo()`/`progress()`/`path(Object)` are **not** overridden by `UnknownMeter` (their own preconditions already reject `startTime == 0`, permanently true for the singleton), but the message their precondition produces — *"Meter not yet started, must call start() first"* — is misleading for an instance that was never meant to be started at all.

## Solution

**Two package-private hooks on `Meter`, no-ops for real meters, overridden by `UnknownMeter`:**

```java
boolean shouldReportInvalidUsage() { return true; }   // real meters: always report
String invalidUsageDiagnosis() { return null; }        // real meters: keep the caller-supplied message
```

- `MeterValidator.logInvalidTransition()`/`logInvalidState()` gate the `CallerStackTraceThrowable` allocation on `getMessageLogger().isErrorEnabled()` **then** `shouldReportInvalidUsage()`, in that order — an `ERROR`-disabled real meter skips the throttle's CAS entirely, not just the allocation.
- **`UnknownMeter`** implements a time-based rate limit: a static `AtomicLong nextAllowedReportNanos` advanced via a CAS loop on `System.nanoTime()`, throttling reports to at most one per `MeterConfig.noopReportIntervalMilliseconds` (default 60000ms; `0` = report every occurrence; negative = never report). A static `AtomicLong suppressedCount` accumulates skipped occurrences and is drained into the next allowed report's message (`"N similar reports suppressed"`).
- `invalidUsageDiagnosis()` also fixes the misleading message: `UnknownMeter` always reports **"no operation is active on the current thread"**, replacing whatever the caller-side precondition would have said.

## API Changes

**New public config property** (additive, non-breaking): `MeterConfig.noopReportIntervalMilliseconds` / system property `slf4jtoys.meter.noop.report.interval`, following the existing `PROP_*` convention (see `MeterConfig.PROP_NOOP_REPORT_INTERVAL`).

**Backward compatibility**: Fully backward compatible. `shouldReportInvalidUsage()`/`invalidUsageDiagnosis()` are package-private hooks with harmless defaults; real `Meter` behavior is unchanged (still reports every misuse, still uses the caller-supplied message). Only `UnknownMeter`'s reporting *frequency* and *wording* change.

## Code Changes

**Production (3 files):**
- `MeterValidator.java` — `logInvalidTransition`/`logInvalidState` gate on `isErrorEnabled()` + `shouldReportInvalidUsage()`, consult `invalidUsageDiagnosis()`.
- `Meter.java` — new hooks + `resetNoopReportThrottle()`; `UnknownMeter` throttle fields/overrides.
- `MeterConfig.java` — `noopReportIntervalMilliseconds` property; `reset()` also resets the throttle's runtime state.

**Tests (2 new files, 1 modified):**
- `MeterUnknownInstanceOverrideInvariantTest` (new) — reflectively enumerates every public, `Meter`/`void`-returning method declared on `Meter`, cross-checks it against a hand-maintained invoker map (failing loudly on drift), and asserts each one leaves `UNKNOWN_INSTANCE`'s observable state (description, context, startTime, stopTime, currentIteration, all paths) unchanged. This is a safety net for methods not yet written: branch `feat/meter-slf4j-message-placeholders` (PR #97) adds `Meter.mf(String, Object...)`, which writes `description` directly behind a precondition that only checks `stopTime` — without an `UnknownMeter` override, merging both branches would silently reintroduce shared-state mutation. Whoever merges second must add that override; this test is what catches it if they don't.
- `MeterUnknownInstanceThrottleTest` (new) — immediate first report, suppression within the interval, suppressed-count embedding after the interval elapses, `0`/negative interval edge cases, real meters never throttled, no `CallerStackTraceThrowable` allocated when `ERROR` is disabled (via `Mockito.mockConstruction`, following the existing `MeterCommonOkGateTest` precedent for proving skipped work, not just its absent output).
- `MeterValidatorTest` — `setUp()` now stubs `meter.shouldReportInvalidUsage()` to `true`. Without it, the unstubbed Mockito mock's boolean method returned `false` (Mockito's default), silently suppressing every `logInvalidState`/`logInvalidTransition` call under test — 16 existing tests failed until this stub was added.

**Docs (1 file):** `doc/TDR-0042-shared-null-object-for-unknown-meter.md` — new "Follow-up: throttling misuse reports" section recording the decision and four rejected alternatives (log-once-ever, per-call-site dedup via stack-trace hashing, backend `DuplicateMessageFilter`, level downgrade to `WARN`).

## Test Results

Full suite, both tiers (`mvnw test -P slf4j-2.0,with-logback`):

- Core tier: **3143** tests — 0 failures, 0 errors
- With-Logback tier: **75** tests — 0 failures, 0 errors
- **BUILD SUCCESS**

## Examples

```java
// Hot loop, no active meter: only the first call (and one every 60s thereafter) logs
for (int i = 0; i < 1_000_000; i++) {
    Meter.getCurrentInstance().progress();
}
// ERROR ... no operation is active on the current thread; id=???#1
// (silence for ~60s)
// ERROR ... no operation is active on the current thread (41823 similar reports suppressed); id=???#1

// Disable throttling entirely (report every occurrence)
System.setProperty(MeterConfig.PROP_NOOP_REPORT_INTERVAL, "0");
// Disable reporting entirely
System.setProperty(MeterConfig.PROP_NOOP_REPORT_INTERVAL, "-1");
```

## Relevant Documentation

- [TDR-0042: Shared Null-Object for the Unknown Meter](https://github.com/useful-toys/slf4j-toys/blob/perf/meter-unknown-instance-throttle/doc/TDR-0042-shared-null-object-for-unknown-meter.md) — updated by this PR with the throttle decision.
- [PR #96](https://github.com/useful-toys/slf4j-toys/pull/96) — the shared null-object this PR follows up on.
- [PR #97](https://github.com/useful-toys/slf4j-toys/pull/97) — adds `Meter.mf()`; the reflective invariant test in this PR is the safety net for that merge order.

## Note on branch provenance

The local branch `perf/meter-unknown-instance-singleton` (backing the already-merged PR #96) had a stale, diverged local worktree that predated two later fixes (`530a65b7`, `d3b25c0c`) already on `main`. This PR starts fresh from current `main` under a new branch name rather than continuing on that stale copy, to avoid reintroducing already-fixed bugs.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
