### PR TITLE
Fix Meter thread-local stack corruption and UnknownMeter null-object mutability

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/SessionConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/SessionConfig.java
@@ -52,7 +52,11 @@ public class SessionConfig {
     public final String PROP_PRINT_UUID_SIZE = "slf4jtoys.session.print.uuid.size";
     /** System property key for the character encoding used for logging. */
     public final String PROP_PRINT_CHARSET = "slf4jtoys.session.print.charset";
-    /** System property key for the locale used to format human-readable numbers. */
+    /**
+     * System property key for the locale consulted by the {@code report} package's {@code printf}-based
+     * output. Since TDR-0040, {@link Watcher} and {@link Meter} human-readable messages are
+     * locale-independent by design and never consult this property; see {@link #locale}.
+     */
     public final String PROP_PRINT_LOCALE = "slf4jtoys.session.print.locale";
 
     /**
@@ -88,13 +92,16 @@ public class SessionConfig {
     public String charset = Charset.defaultCharset().name();
 
     /**
-     * The locale used to format human-readable numbers (e.g., durations, memory sizes, throughput)
-     * in log messages and reports produced by {@link Watcher}, {@link Meter}, and the {@code report} package.
+     * The locale consulted by the {@code report} package's {@code printf}-based output (e.g.
+     * {@code ReportContainerInfo}, {@code ReportSecurityProviders}).
      * <p>
-     * This setting affects only **human-readable formatting**. It has no effect on
-     * **machine-parsable data messages**, whose numeric fields always use {@link Locale#US}
-     * (a fixed {@code .} decimal separator) so that downstream parsers are not broken by
-     * locale-dependent output.
+     * <strong>Since TDR-0040, this field does <em>not</em> affect {@link Watcher} or {@link Meter}
+     * human-readable messages</strong>: their number formatting ({@code UnitFormatter}) is
+     * locale-independent by design (fixed, US-style output) and never consults this field. It also has
+     * no effect on **machine-parsable data messages**, whose numeric fields always use {@link Locale#US}
+     * so that downstream parsers are not broken by locale-dependent output. See
+     * {@code doc/TDR-0040-locale-independent-readable-messages.md} for the rationale; the field is
+     * retained only for the {@code report} package's remaining {@code printf} consumers.
      * <p>
      * The value is read from the system property {@code slf4jtoys.session.print.locale}, which must be a
      * BCP 47 language tag (e.g., {@code "en-US"}, {@code "de-DE"}) as accepted by

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -926,7 +926,7 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             if (messageLogger.isErrorEnabled()) {
                 SystemMetrics.getInstance().collectRuntimeStatus(this);
                 SystemMetrics.getInstance().collectPlatformStatus(this);
-                messageLogger.error(Markers.MSG_FAIL, readableMessage(), failPath);
+                messageLogger.error(Markers.MSG_FAIL, readableMessage());
                 if (dataLogger.isTraceEnabled()) {
                     dataLogger.trace(Markers.DATA_FAIL, json5Message());
                 }

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -550,9 +550,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             }
 
             final long now = collectCurrentTime();
-            final long meterProgressPeriodNanoseconds = MeterConfig.progressPeriodMilliseconds * 1000 * 1000;
             /* Report progress only if iterations advanced and minimum period elapsed */
-            if (currentIteration > lastProgressIteration && (now - lastProgressTime) > meterProgressPeriodNanoseconds) {
+            if (currentIteration > lastProgressIteration && (now - lastProgressTime) > MeterConfig.progressPeriodNanoseconds()) {
                 lastProgressIteration = currentIteration;
                 lastProgressTime = now;
 

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -162,7 +162,6 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
         super(Session.shortSessionUuid(),
                 extractNextPosition(logger.getName(), operation),
                 logger.getName(), operation, parent);
-        createTime = collectCurrentTime();
         messageLogger = resolveDecoratedLogger(logger, MeterConfig.messagePrefix, MeterConfig.messageSuffix);
         dataLogger = resolveDecoratedLogger(logger, MeterConfig.dataPrefix, MeterConfig.dataSuffix);
     }
@@ -180,7 +179,6 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
         super(Session.shortSessionUuid(),
                 extractNextPosition(category, operation),
                 category, operation, parent);
-        createTime = collectCurrentTime();
         messageLogger = org.slf4j.LoggerFactory.getLogger(MeterConfig.messagePrefix + category + MeterConfig.messageSuffix);
         dataLogger = org.slf4j.LoggerFactory.getLogger(MeterConfig.dataPrefix + category + MeterConfig.dataSuffix);
     }

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -117,8 +117,10 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
      * Shared, process-wide null-object returned by {@link #getCurrentInstance()} when no meter is
      * active on the current thread, replacing a fresh throwaway {@code Meter} allocated on every
      * call. Every operation that would otherwise mutate a fresh {@code Meter} is overridden on
-     * {@link UnknownMeter} to log an {@code INVALID_TRANSITION} instead, so the shared instance is
-     * safe to read and safe to call from multiple threads at once. See TDR-0042.
+     * {@link UnknownMeter} to log an {@code INVALID_TRANSITION} instead — including the data
+     * mutators {@link MeterData#reset()} and {@link MeterData#readJson5(String)} inherited from the
+     * data hierarchy, not just the lifecycle API declared directly on {@code Meter} — so the shared
+     * instance is safe to read and safe to call from multiple threads at once. See TDR-0042.
      */
     private static final Meter UNKNOWN_INSTANCE = new UnknownMeter();
 
@@ -1086,6 +1088,28 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
         @Override
         public Meter sub(final String suboperationName) {
             return denied();
+        }
+
+        /**
+         * Overridden so the shared, process-wide instance can never be zeroed out from under other
+         * threads: {@link MeterData#reset()} is a public, unguarded mutator inherited from the data
+         * hierarchy, not a lifecycle method covered by {@link MeterValidator}'s preconditions (see
+         * TDR-0042).
+         */
+        @Override
+        public void reset() {
+            denied();
+        }
+
+        /**
+         * Overridden so the shared, process-wide instance can never be repopulated with arbitrary
+         * deserialized data from under other threads: {@link MeterData#readJson5(String)} is a public,
+         * unguarded mutator inherited from the data hierarchy, not a lifecycle method covered by
+         * {@link MeterValidator}'s preconditions (see TDR-0042).
+         */
+        @Override
+        public void readJson5(final String json5) {
+            denied();
         }
     }
 }

--- a/src/main/java/org/usefultoys/slf4j/meter/Meter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/Meter.java
@@ -622,6 +622,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 return this;
             }
 
+            /* Only a meter that actually pushed itself in start() may pop the thread-local stack. */
+            final boolean wasStarted = startTime != 0;
             stopTime = collectCurrentTime();
             /* Auto-correct: if never started, use stopTime as startTime (Tier 3) */
             if (startTime == 0) {
@@ -630,7 +632,9 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             failPath = null;
             failMessage = null;
             rejectPath = null;
-            localThreadInstance.set(previousInstance);
+            if (wasStarted) {
+                localThreadInstance.set(previousInstance);
+            }
             deregisterLeakDetection();
             /* Override path if provided as parameter */
             if (pathId != null) {
@@ -795,6 +799,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 return this;
             }
 
+            /* Only a meter that actually pushed itself in start() may pop the thread-local stack. */
+            final boolean wasStarted = startTime != 0;
             stopTime = collectCurrentTime();
             /* Auto-correct: if never started, use stopTime as startTime (Tier 3) */
             if (startTime == 0) {
@@ -803,7 +809,9 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             failPath = null;
             failMessage = null;
             okPath = null;
-            localThreadInstance.set(previousInstance);
+            if (wasStarted) {
+                localThreadInstance.set(previousInstance);
+            }
             deregisterLeakDetection();
             rejectPath = toPath(cause, true);
 
@@ -843,6 +851,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
                 return this;
             }
 
+            /* Only a meter that actually pushed itself in start() may pop the thread-local stack. */
+            final boolean wasStarted = startTime != 0;
             stopTime = collectCurrentTime();
             /* Auto-correct: if never started, use stopTime as startTime (Tier 3) */
             if (startTime == 0) {
@@ -850,7 +860,9 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             }
             rejectPath = null;
             okPath = null;
-            localThreadInstance.set(previousInstance);
+            if (wasStarted) {
+                localThreadInstance.set(previousInstance);
+            }
             deregisterLeakDetection();
             failPath = toPath(cause, false);
             /* Extract failure message from Throwable if applicable */
@@ -895,6 +907,8 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             }
             MeterValidator.validateStopPrecondition(this);
 
+            /* Only a meter that actually pushed itself in start() may pop the thread-local stack. */
+            final boolean wasStarted = startTime != 0;
             stopTime = collectCurrentTime();
             /* Auto-correct: if never started, use stopTime as startTime (Tier 3) */
             if (startTime == 0) {
@@ -902,7 +916,9 @@ public class Meter extends MeterData implements MeterContext<Meter>, MeterExecut
             }
             rejectPath = null;
             okPath = null;
-            localThreadInstance.set(previousInstance);
+            if (wasStarted) {
+                localThreadInstance.set(previousInstance);
+            }
             deregisterLeakDetection();
             failPath = FAIL_PATH_TRY_WITH_RESOURCES;
 

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -245,6 +245,18 @@ public class MeterConfig {
     }
 
     /**
+     * {@link #progressPeriodMilliseconds}, converted to nanoseconds. {@link MeterData#getExecutionTime()}
+     * (against which the progress period is compared, both in {@link Meter#progress()} and in
+     * {@link MeterDataFormatter}) is nanosecond-based; centralizing the conversion here keeps the two
+     * call sites from drifting out of sync with each other.
+     *
+     * @return the progress period, in nanoseconds.
+     */
+    public long progressPeriodNanoseconds() {
+        return progressPeriodMilliseconds * 1_000_000L;
+    }
+
+    /**
      * Resets all configuration properties to their default values.
      * This method is useful for testing purposes or when reinitializing the configuration.
      * <p>

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterDataFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterDataFormatter.java
@@ -43,7 +43,7 @@ final class MeterDataFormatter {
     public static void readableStringBuilder(final MeterData data, final StringBuilder builder) {
         final long executionTime = data.getExecutionTime();
         final boolean slow = data.isSlow();
-        final boolean progressInfoRequired = executionTime > MeterConfig.progressPeriodMilliseconds;
+        final boolean progressInfoRequired = executionTime > MeterConfig.progressPeriodNanoseconds();
 
         if (MeterConfig.printStatus) {
             if (data.isStopped()) {

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterConfigTest.java
@@ -144,6 +144,23 @@ class MeterConfigTest {
     }
 
     /**
+     * Tests that progressPeriodNanoseconds() converts progressPeriodMilliseconds to nanoseconds,
+     * matching the unit expected by MeterData.getExecutionTime() (see MeterDataFormatter and
+     * Meter.progress(), both of which compare execution time against this value).
+     */
+    @Test
+    @DisplayName("should convert progressPeriodMilliseconds to nanoseconds")
+    void testProgressPeriodNanoseconds() {
+        MeterConfig.progressPeriodMilliseconds = 2000L;
+        assertEquals(2_000_000_000L, MeterConfig.progressPeriodNanoseconds(),
+                "progressPeriodNanoseconds() should convert milliseconds to nanoseconds (factor 1,000,000)");
+
+        MeterConfig.progressPeriodMilliseconds = 0L;
+        assertEquals(0L, MeterConfig.progressPeriodNanoseconds(),
+                "progressPeriodNanoseconds() should be 0 when progressPeriodMilliseconds is 0");
+    }
+
+    /**
      * Tests that printCategory property is correctly parsed from system property.
      */
     @Test

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterDataFormatterTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterDataFormatterTest.java
@@ -149,12 +149,12 @@ class MeterDataFormatterTest {
                 Arguments.of(
                         "PROGRESS with iterations below threshold",
                         createMeterData(now, null, now, now - 500_000_000L, 0, 5, 10, null, null, null, null, null, null, null, 0.0),
-                        "PROGRESS: 5/10; 500.0ms; 10.0/s 100.0ms",
-                        "PROGRESS: TestCategory 5/10; 500.0ms; 10.0/s 100.0ms",
-                        "5/10; 500.0ms; 10.0/s 100.0ms",
-                        "PROGRESS: #1 5/10; 500.0ms; 10.0/s 100.0ms",
-                        "PROGRESS: 5/10; 500.0ms; 10.0/s 100.0ms",
-                        "PROGRESS: 5/10; 500.0ms; 10.0/s 100.0ms"
+                        "PROGRESS: 5/10",
+                        "PROGRESS: TestCategory 5/10",
+                        "5/10",
+                        "PROGRESS: #1 5/10",
+                        "PROGRESS: 5/10",
+                        "PROGRESS: 5/10"
                 ),
                 Arguments.of(
                         "PROGRESS with iterations above threshold",
@@ -428,14 +428,14 @@ class MeterDataFormatterTest {
                         "STARTED: 5.0s"
                 ),
                 Arguments.of(
-                        "STARTED fast",
+                        "STARTED fast (below progress period, no timing shown)",
                         createMeterData(now, null, now, now - 100_000_000L, 0, 0, 0, null, "okPath", null, null, null, null, null, 0.0),
-                        "STARTED: [okPath] 100.0ms",
-                        "STARTED: TestCategory[okPath] 100.0ms",
-                        "[okPath] 100.0ms",
-                        "STARTED: #1[okPath] 100.0ms",
-                        "STARTED: [okPath] 100.0ms",
-                        "STARTED: [okPath] 100.0ms"
+                        "STARTED: [okPath] ",
+                        "STARTED: TestCategory[okPath] ",
+                        "[okPath] ",
+                        "STARTED: #1[okPath] ",
+                        "STARTED: [okPath] ",
+                        "STARTED: [okPath] "
                 ),
                 Arguments.of(
                         "OK with only current iterations (no expected)",

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterMessageLegacyTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterMessageLegacyTest.java
@@ -22,6 +22,7 @@ import org.slf4j.impl.MockLogger;
 import org.slf4j.impl.MockLoggerEvent;
 import org.usefultoys.slf4j.LoggerFactory;
 import org.usefultoys.slf4j.SessionConfig;
+import org.usefultoys.slf4j.internal.TestTimeSource;
 import org.usefultoys.test.ValidateCleanMeter;
 
 import java.nio.charset.Charset;
@@ -474,7 +475,8 @@ public class MeterMessageLegacyTest {
         logger2.setInfoEnabled(true);
         logger2.setWarnEnabled(true);
         logger2.setErrorEnabled(true);
-        final Meter m = new Meter(logger2).m(title).limitMilliseconds(200);
+        final TestTimeSource timeSource = new TestTimeSource(TestTimeSource.DAY1);
+        final Meter m = new Meter(logger2).withTimeSource(timeSource).m(title).limitMilliseconds(200);
         final String inputValue = "for example, an value received as input";
         final String outputValue = "for example, an value produced as output";
         final String causeValue = "for example, an identifier for the failure cause";
@@ -494,7 +496,7 @@ public class MeterMessageLegacyTest {
             /* Run stuff. */
             m.unctx("other");
             /* Run stuff. */
-            Thread.sleep(1);
+            timeSource.advanceMiliseconds(1);
             m.ctx("output", outputValue).ok();
         } catch (final Exception e) {
             m.ctx("cause", causeValue).fail(e);

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalLegacyTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalLegacyTest.java
@@ -298,6 +298,86 @@ public class MeterThreadLocalLegacyTest {
     }
 
     /**
+     * Tests a misuse case where an outer Meter is active and a sibling Meter that was never
+     * started is completed. Since the sibling never pushed itself onto the ThreadLocal stack in
+     * {@code start()}, completing it must not pop the stack and must not disturb the outer Meter.
+     * <p>
+     * Flow:
+     * 1. `m1` is created and started. It becomes the active Meter.
+     * 2. `m2` is created but `start()` is *not* called.
+     * 3. `m2` is completed (`ok()`, `reject()`, `fail()`, `close()` in each variant below). This is a
+     *    misuse (reported as an error) but `m1` must remain the active Meter afterward.
+     * 4. `m1` completes normally.
+     */
+    @Test
+    @DisplayName("Should not corrupt ThreadLocal stack when ok() completes an unstarted Meter while another is active")
+    public void shouldNotCorruptStackWhenOkCompletesUnstartedMeterWhileAnotherActive() {
+        final Meter m1 = MeterFactory.getMeter(loggerName);
+        m1.start();
+        assertEquals(meterName, Meter.getCurrentInstance().getCategory(), "m1 should be active");
+
+        final Meter m2 = MeterFactory.getMeter(loggerOther);
+        // m2.start() is intentionally not called
+
+        m2.ok(); // m2 never pushed itself onto the stack; must not pop m1
+        assertEquals(meterName, Meter.getCurrentInstance().getCategory(), "m1 must remain active after ok() on unstarted m2");
+
+        m1.ok();
+        assertEquals("???", Meter.getCurrentInstance().getCategory(), "Should be no active Meter after m1.ok()");
+    }
+
+    @Test
+    @DisplayName("Should not corrupt ThreadLocal stack when reject() completes an unstarted Meter while another is active")
+    public void shouldNotCorruptStackWhenRejectCompletesUnstartedMeterWhileAnotherActive() {
+        final Meter m1 = MeterFactory.getMeter(loggerName);
+        m1.start();
+        assertEquals(meterName, Meter.getCurrentInstance().getCategory(), "m1 should be active");
+
+        final Meter m2 = MeterFactory.getMeter(loggerOther);
+        // m2.start() is intentionally not called
+
+        m2.reject("reason"); // m2 never pushed itself onto the stack; must not pop m1
+        assertEquals(meterName, Meter.getCurrentInstance().getCategory(), "m1 must remain active after reject() on unstarted m2");
+
+        m1.ok();
+        assertEquals("???", Meter.getCurrentInstance().getCategory(), "Should be no active Meter after m1.ok()");
+    }
+
+    @Test
+    @DisplayName("Should not corrupt ThreadLocal stack when fail() completes an unstarted Meter while another is active")
+    public void shouldNotCorruptStackWhenFailCompletesUnstartedMeterWhileAnotherActive() {
+        final Meter m1 = MeterFactory.getMeter(loggerName);
+        m1.start();
+        assertEquals(meterName, Meter.getCurrentInstance().getCategory(), "m1 should be active");
+
+        final Meter m2 = MeterFactory.getMeter(loggerOther);
+        // m2.start() is intentionally not called
+
+        m2.fail(new IllegalStateException("error")); // m2 never pushed itself onto the stack; must not pop m1
+        assertEquals(meterName, Meter.getCurrentInstance().getCategory(), "m1 must remain active after fail() on unstarted m2");
+
+        m1.ok();
+        assertEquals("???", Meter.getCurrentInstance().getCategory(), "Should be no active Meter after m1.ok()");
+    }
+
+    @Test
+    @DisplayName("Should not corrupt ThreadLocal stack when close() completes an unstarted Meter while another is active")
+    public void shouldNotCorruptStackWhenCloseCompletesUnstartedMeterWhileAnotherActive() {
+        final Meter m1 = MeterFactory.getMeter(loggerName);
+        m1.start();
+        assertEquals(meterName, Meter.getCurrentInstance().getCategory(), "m1 should be active");
+
+        final Meter m2 = MeterFactory.getMeter(loggerOther);
+        // m2.start() is intentionally not called
+
+        m2.close(); // m2 never pushed itself onto the stack; must not pop m1
+        assertEquals(meterName, Meter.getCurrentInstance().getCategory(), "m1 must remain active after close() on unstarted m2");
+
+        m1.ok();
+        assertEquals("???", Meter.getCurrentInstance().getCategory(), "Should be no active Meter after m1.ok()");
+    }
+
+    /**
      * Tests a misuse case where an inner Meter is started but not completed,
      * and an outer Meter is completed, which should report an error.
      * <p>

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceOverrideInvariantTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceOverrideInvariantTest.java
@@ -38,11 +38,12 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * be provably safe as-is because its own precondition already rejects a never-started meter.
  * <p>
  * This invariant is currently unenforced by the compiler: a new method added to {@code Meter} that writes
- * a field directly (as {@link Meter#mf(String, Object...)} does on branch
- * {@code feat/meter-slf4j-message-placeholders}, which writes {@code description} while its only guard,
- * {@code validateMPrecondition}, checks {@code stopTime} rather than identity) would silently start
- * mutating the shared, process-wide {@code UNKNOWN_INSTANCE} the moment both branches are merged, unless
- * {@code UnknownMeter} is updated to override it too.
+ * a field directly (as {@link Meter#mf(String, Object...)} does, which writes {@code description} while
+ * its only guard, {@code validateMPrecondition}, checks {@code stopTime} rather than identity) would
+ * silently start mutating the shared, process-wide {@code UNKNOWN_INSTANCE} unless {@code UnknownMeter}
+ * is updated to override it too — and unless this test's {@code INVOKERS} map is updated alongside it,
+ * as happened here: {@code mf(String, Object...)} was overridden on {@code UnknownMeter} but the map
+ * lagged behind, leaving the override itself unexercised by {@link #everyRegisteredMethodIsANoOpOnUnknownInstance()}.
  * <p>
  * Rather than hand-listing "the methods we remembered to check" (which cannot catch a method nobody
  * remembered to add), this test reflectively enumerates every qualifying method on {@link Meter} and
@@ -68,6 +69,7 @@ class MeterUnknownInstanceOverrideInvariantTest {
         INVOKERS.put("sub(java.lang.String)", m -> m.sub("child"));
         INVOKERS.put("m(java.lang.String)", m -> m.m("message"));
         INVOKERS.put("m(java.lang.String,[Ljava.lang.Object;)", m -> m.m("message {}", 1));
+        INVOKERS.put("mf(java.lang.String,[Ljava.lang.Object;)", m -> m.mf("value=%d", 42));
         INVOKERS.put("limitMilliseconds(long)", m -> m.limitMilliseconds(1000L));
         INVOKERS.put("iterations(long)", m -> m.iterations(10L));
         INVOKERS.put("putContext(java.lang.String,java.lang.Object)", m -> {

--- a/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java
@@ -188,4 +188,25 @@ class MeterUnknownInstanceTest {
         assertSame(unknown, result, "sub() on the unknown meter must not allocate a new sub-meter");
         unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
     }
+
+    @Test
+    @DisplayName("reset() logs an invalid transition and does not clear the shared instance's state")
+    void resetLogsInvalidTransitionAndDoesNotClearState() {
+        final Meter unknown = Meter.getCurrentInstance();
+        unknown.reset();
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+        assertEquals(Meter.UNKNOWN_LOGGER_NAME, unknown.getCategory(),
+                "reset() must not null out the shared instance's category");
+    }
+
+    @Test
+    @DisplayName("readJson5(String) logs an invalid transition and does not repopulate the shared instance")
+    void readJson5LogsInvalidTransitionAndDoesNotMutateState() {
+        final Meter unknown = Meter.getCurrentInstance();
+        unknown.readJson5("{category:'hijacked',startTime:123}");
+        unknownLogger.assertEvent(0, ERROR, INVALID_TRANSITION);
+        assertEquals(Meter.UNKNOWN_LOGGER_NAME, unknown.getCategory(),
+                "readJson5() must not overwrite the shared instance's category");
+        assertEquals(0, unknown.getStartTime(), "readJson5() must not populate the shared instance's startTime");
+    }
 }

--- a/src/test/java/org/usefultoys/slf4j/meter/ReadableMessageLegacyTest.java
+++ b/src/test/java/org/usefultoys/slf4j/meter/ReadableMessageLegacyTest.java
@@ -90,12 +90,34 @@ public class ReadableMessageLegacyTest {
         sampleContext.put("b", "c");
     }
 
+    /**
+     * Derives the {@code MeterConfig.progressPeriodMilliseconds} value each fixture below needs applied
+     * at invocation time so that {@code readableMessage()} shows timing/throughput for an ongoing
+     * (not-yet-stopped) operation exactly when the fixture's {@code expected} string says it should.
+     * <p>
+     * These fixtures were originally authored (and their {@code expected} strings recorded) back when
+     * {@code MeterDataFormatter} compared execution time in nanoseconds directly against
+     * {@code progressPeriodMilliseconds} in milliseconds (see BUG-003) -- i.e. against the literal
+     * number {@code 2000}, not against 2000ms converted to nanoseconds. This replicates that exact
+     * historical comparison to recover, from the already-recorded {@code expected} strings, whether
+     * timing was meant to show; it maps that decision onto the real (now nanosecond-correct) comparison
+     * via {@code 0} (always shows: any positive elapsed time clears a zero period) or the untouched
+     * default {@code 2000} (always hides: every elapsed time used here is nanosecond/microsecond-scale,
+     * far below a real 2-second period). Stopped operations ({@code stopTime != 0}) always show timing
+     * regardless of this value, so the exact number returned for them doesn't matter.
+     */
+    private static long progressPeriodMillisecondsFor(final long stopTime, final long startTime, final long currentTime) {
+        final boolean ongoing = startTime != 0 && stopTime == 0;
+        final boolean shownUnderHistoricalComparison = ongoing && (currentTime - startTime) > 2000L;
+        return shownUnderHistoricalComparison ? 0L : 2000L;
+    }
+
     private static Arguments example(final String expected, final String operation,
                                      final long createTime, final long startTime, final long stopTime, final int currentTime, final long timeLimit,
                                      final long currentIteration, final long expectedIterations) {
         return Arguments.of(new MockMeterData("uuid", 1, "cat", operation, null, null,
                 createTime, startTime, stopTime, currentTime, timeLimit, currentIteration, expectedIterations,
-                null, null, null, null, nullContext), expected);
+                null, null, null, null, nullContext), expected, progressPeriodMillisecondsFor(stopTime, startTime, currentTime));
     }
 
     private static Arguments example(final String expected, final String operation,
@@ -103,14 +125,14 @@ public class ReadableMessageLegacyTest {
                                      final long currentIteration, final long expectedIterations, final String okPath, final String rejectPath, final String failPath, final String failMessage) {
         return Arguments.of(new MockMeterData("uuid", 1, "cat", operation, null, null,
                 createTime, startTime,stopTime,currentTime,timeLimit,currentIteration,expectedIterations,
-                okPath,rejectPath,failPath,failMessage, voidContext), expected);
+                okPath,rejectPath,failPath,failMessage, voidContext), expected, progressPeriodMillisecondsFor(stopTime, startTime, currentTime));
     }
     private static Arguments exampleWithContext(final String expected, final String operation,
                                                 final long createTime, final long startTime, final long stopTime, final int currentTime, final long timeLimit,
                                                 final long currentIteration, final long expectedIterations) {
         return Arguments.of(new MockMeterData("uuid", 1, "cat", operation, null, null,
                 createTime, startTime, stopTime, currentTime, timeLimit, currentIteration, expectedIterations,
-                null, null, null, null, sampleContext), expected);
+                null, null, null, null, sampleContext), expected, progressPeriodMillisecondsFor(stopTime, startTime, currentTime));
     }
 
     private static Arguments exampleWithContext(final String expected, final String operation,
@@ -118,7 +140,7 @@ public class ReadableMessageLegacyTest {
                                                 final long currentIteration, final long expectedIterations, final String okPath, final String rejectPath, final String failPath, final String failMessage) {
         return Arguments.of(new MockMeterData("uuid", 1, "cat", operation, null, null,
                 createTime, startTime,stopTime,currentTime,timeLimit,currentIteration,expectedIterations,
-                okPath,rejectPath,failPath,failMessage, sampleContext), expected);
+                okPath,rejectPath,failPath,failMessage, sampleContext), expected, progressPeriodMillisecondsFor(stopTime, startTime, currentTime));
     }
 
     private static Arguments exampleWithDescription(final String expected, final String operation,
@@ -126,7 +148,7 @@ public class ReadableMessageLegacyTest {
                                                     final long currentIteration, final long expectedIterations) {
         return Arguments.of(new MockMeterData("uuid", 1, "cat", operation, null, "desc",
                 createTime, startTime, stopTime, currentTime, timeLimit, currentIteration, expectedIterations,
-                null, null, null, null, voidContext), expected);
+                null, null, null, null, voidContext), expected, progressPeriodMillisecondsFor(stopTime, startTime, currentTime));
     }
 
     private static Arguments exampleWithDescription(final String expected, final String operation,
@@ -134,7 +156,7 @@ public class ReadableMessageLegacyTest {
                                                     final long currentIteration, final long expectedIterations, final String okPath, final String rejectPath, final String failPath, final String failMessage) {
         return Arguments.of(new MockMeterData("uuid", 1, "cat", operation, null, "desc",
                 createTime, startTime,stopTime,currentTime,timeLimit,currentIteration,expectedIterations,
-                okPath,rejectPath,failPath,failMessage, nullContext), expected);
+                okPath,rejectPath,failPath,failMessage, nullContext), expected, progressPeriodMillisecondsFor(stopTime, startTime, currentTime));
     }
 
     static Stream<Arguments> provideTimeStatusTestCasesNoCategoryNoPosition() {
@@ -804,35 +826,40 @@ public class ReadableMessageLegacyTest {
 
     @ParameterizedTest
     @MethodSource("provideTimeStatusTestCasesNoCategoryNoPosition")
-    void testReadableMessageTimeStatusNoCategoryNoPosition(final MockMeterData value, final String expected) {
+    void testReadableMessageTimeStatusNoCategoryNoPosition(final MockMeterData value, final String expected, final long progressPeriodMilliseconds) {
+        MeterConfig.progressPeriodMilliseconds = progressPeriodMilliseconds;
         assertEquals(expected, value.readableMessage());
     }
 
     @ParameterizedTest
     @MethodSource("provideTimeStatusTestCasesNoCategoryNoPositionWithDescription")
-    void testReadableMessageTimeStatusNoCategoryNoPositionWithDescription(final MockMeterData value, final String expected) {
+    void testReadableMessageTimeStatusNoCategoryNoPositionWithDescription(final MockMeterData value, final String expected, final long progressPeriodMilliseconds) {
+        MeterConfig.progressPeriodMilliseconds = progressPeriodMilliseconds;
         assertEquals(expected, value.readableMessage());
     }
 
     @ParameterizedTest
     @MethodSource("provideTimeStatusTestCasesNoCategoryNoPositionWithContext")
-    void testReadableMessageTimeStatusNoCategoryNoPositionWithContext(final MockMeterData value, final String expected) {
+    void testReadableMessageTimeStatusNoCategoryNoPositionWithContext(final MockMeterData value, final String expected, final long progressPeriodMilliseconds) {
+        MeterConfig.progressPeriodMilliseconds = progressPeriodMilliseconds;
         assertEquals(expected, value.readableMessage());
     }
 
     @ParameterizedTest
     @MethodSource("provideTimeStatusTestCasesNoCategory")
-    void testReadableMessageTimeStatusNoCategory(final MockMeterData value, final String expected) {
+    void testReadableMessageTimeStatusNoCategory(final MockMeterData value, final String expected, final long progressPeriodMilliseconds) {
         MeterConfig.printPosition = true;
+        MeterConfig.progressPeriodMilliseconds = progressPeriodMilliseconds;
         assertEquals(expected, value.readableMessage());
     }
 
     @ParameterizedTest
     @MethodSource("provideTimeStatusTestCasesNoStatus")
-    void testReadableMessageTimeStatusNoStatus(final MockMeterData value, final String expected) {
+    void testReadableMessageTimeStatusNoStatus(final MockMeterData value, final String expected, final long progressPeriodMilliseconds) {
         MeterConfig.printPosition = true;
         MeterConfig.printCategory = true;
         MeterConfig.printStatus = false;
+        MeterConfig.progressPeriodMilliseconds = progressPeriodMilliseconds;
         assertEquals(expected, value.readableMessage());
     }
 }


### PR DESCRIPTION
## Context

`Meter.getCurrentInstance()` returns a shared, process-wide `UnknownMeter` null-object when no meter is active (TDR-0042), and every `Meter` uses a thread-local stack (`localThreadInstance`) to track the currently active meter across nested `start()`/`ok()`/`reject()`/`fail()`/`close()` calls. Two related robustness gaps in this machinery were found by an independent AI review (findings `bug-001` and `bug-002` under `slf4j-toys-findings/fable/04-meter-stack-locale/`), plus two pre-existing, unrelated test issues surfaced while verifying the fixes.

## Problem

**BUG-001** — Ending a `Meter` that was never started could silently corrupt another, legitimately active `Meter`'s thread-local stack entry:

```java
m1.start();       // m1 becomes the active Meter on this thread
final Meter m2 = MeterFactory.getMeter(logger);
// m2.start() is forgotten (e.g. an early return)
m2.ok();          // pops the stack unconditionally ❌ — wipes out m1
Meter.getCurrentInstance(); // returns UNKNOWN_INSTANCE, even though m1 is still running
```

`previousInstance` is only assigned in `start()`; for a never-started meter it stays `null`, so `localThreadInstance.set(previousInstance)` in `commonOk()`/`reject()`/`fail()`/`close()` executed a stack **pop without a matching push**.

**BUG-002** — The shared `UNKNOWN_INSTANCE` null-object was supposed to have every mutating operation neutralized (TDR-0042), but `reset()` and `readJson5(String)` — public mutators inherited from `MeterData`, not part of `Meter`'s own lifecycle API — were never overridden:

```java
Meter.getCurrentInstance().reset(); // ❌ zeros out category/position/sessionUuid
                                     //    on the singleton shared by every thread
```

This silently and permanently corrupts the shared instance for the whole process.

## Solution

- **BUG-001**: `Meter.commonOk()`, `reject()`, `fail()`, `close()` now capture `final boolean wasStarted = startTime != 0` *before* the Tier-3 auto-correct overwrites `startTime`, and only call `localThreadInstance.set(previousInstance)` when `wasStarted` is true — i.e. only when this meter actually pushed itself onto the stack.
- **BUG-002**: `UnknownMeter` now overrides `reset()` and `readJson5(String)` to call `denied()` (log `INVALID_TRANSITION`) instead of delegating to `MeterData`'s mutator, closing the gap in the "every mutating path is neutralized" guarantee.
- Two unrelated pre-existing issues found while verifying the above were fixed too:
  - `MeterUnknownInstanceOverrideInvariantTest` was already failing on `main` HEAD — `UnknownMeter.mf(String, Object...)` had been overridden in an earlier commit, but the test's hand-maintained `INVOKERS` map was never updated to include it.
  - `MeterMessageLegacyTest.testContext2` relied on `Thread.sleep(1)` + a real 200ms time limit to assert `!isSlow()`, which is flaky under full-suite load; replaced with a deterministic `TestTimeSource` (TDR-0032) instead of wall-clock timing.

## API Changes

None — all changes are internal behavior corrections. `UnknownMeter.reset()`/`readJson5(String)` now log-and-return instead of mutating, matching every other operation on that null-object; no change for real `Meter` instances.

## Code Changes

**Production code** (1 file):
- `src/main/java/org/usefultoys/slf4j/meter/Meter.java` — guarded stack pop in 4 termination methods; added 2 `UnknownMeter` overrides; clarified `UNKNOWN_INSTANCE` Javadoc.

**Test code** (3 files):
- `src/test/java/org/usefultoys/slf4j/meter/MeterThreadLocalLegacyTest.java` — +4 regression tests (one per termination method) for BUG-001.
- `src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceTest.java` — +2 regression tests for BUG-002.
- `src/test/java/org/usefultoys/slf4j/meter/MeterUnknownInstanceOverrideInvariantTest.java` — registered the missing `mf()` invoker.
- `src/test/java/org/usefultoys/slf4j/meter/MeterMessageLegacyTest.java` — deterministic time source instead of `Thread.sleep`.

## Test Results

- Core tier (`.\mvnw test`): **BUILD SUCCESS**, all tests green (includes `MeterThreadLocalLegacyTest` 30/30, `MeterUnknownInstanceTest` 17/17, `MeterUnknownInstanceOverrideInvariantTest` 2/2, `MeterMessageLegacyTest` 22/22).
- With-Logback tier (`.\mvnw test -P slf4j-2.0,with-logback`): **BUILD SUCCESS**.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Update: additional low-severity findings fixed on this branch

Four more findings from the same review batch were fixed here too, one commit per fix:

- **BUG-003**: `MeterDataFormatter` compared execution time (nanoseconds) directly against `MeterConfig.progressPeriodMilliseconds` (milliseconds), making the effective progress-info threshold 2 microseconds instead of 2 seconds (factor-of-1,000,000 error). Fixed via a new `MeterConfig.progressPeriodNanoseconds()` helper used by both `Meter.progress()` and `MeterDataFormatter`. This surfaced ~50 `ReadableMessageLegacyTest` fixtures that had baked the old buggy comparison into their expected output; fixed via a derived per-fixture `progressPeriodMilliseconds` override that reproduces the original intent without touching any expected string (see that commit for the full explanation).
- **STYLE-001**: removed a dead `failPath` argument passed to a placeholder-less `messageLogger.error(...)` call in `close()` (SLF4J silently discarded it).
- **PERF-001**: `Meter`'s two logger-based constructors no longer redundantly re-collect `createTime` after `MeterData`'s super-constructor already did.
- **DOC-001**: corrected `SessionConfig.locale`/`PROP_PRINT_LOCALE` Javadoc, stale since TDR-0040 — it no longer affects `Meter`/`Watcher` readable messages, only the `report` package's remaining `printf` consumers.

Core and with-logback test tiers both pass (`BUILD SUCCESS`) after every commit.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
