### PR TITLE
Stamp JMH benchmark result JSON with the measured library's git commit

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -167,16 +167,63 @@ Goal: prove an optimization to the library is a real improvement.
 # ---------- ANTES / BEFORE: the library without the change ----------
 .\mvnw -DskipTests install                       # install the "before" library
 .\mvnw -f benchmarks\pom.xml compile exec:java "-Dexec.args=MeterOperationBenchmark|MeterLifecycleBenchmark -prof gc -rf json -rff before.json"
+.\benchmarks\stamp-provenance.ps1 before.json    # record which library commit this measured
 
 # ---------- apply the optimization to the library, then ----------
 # ---------- DEPOIS / AFTER: the library with the change ----------
 .\mvnw -DskipTests install                       # reinstall the "after" library
 .\mvnw -f benchmarks\pom.xml compile exec:java "-Dexec.args=MeterOperationBenchmark|MeterLifecycleBenchmark -prof gc -rf json -rff after.json"
+.\benchmarks\stamp-provenance.ps1 after.json     # record which library commit this measured
 ```
 
 `-rf json -rff <file>` writes machine-readable results. Compare `before.json` and
 `after.json` method by method, on both `Score` and `gc.alloc.rate.norm`. Declare a win
 only when the change exceeds the error margins on both sides.
+
+### Recording which commit a result measured (provenance)
+
+A stored baseline is only useful later if you know **which library commit it measured**.
+`stamp-provenance.ps1` reads the Git provenance the build stamps into the measured jar
+(`META-INF/git.properties`, backed by the `SCM-*` manifest entries — see the root
+`pom.xml`) and wraps the JMH result file so the commit travels with the numbers:
+
+```powershell
+.\benchmarks\stamp-provenance.ps1 after.json
+```
+
+turns JMH's plain top-level array into
+
+```json
+{
+  "provenance": {
+    "available": true,
+    "source": "slf4j-toys-2.1.0-SNAPSHOT.jar (META-INF/git.properties)",
+    "git.commit.id.abbrev": "9926b411",
+    "git.branch": "main",
+    "git.dirty": false,
+    "git.commit.id.describe": "2.0.0-145-g9926b411",
+    "...": "..."
+  },
+  "results": [ /* the original JMH array, unchanged */ ]
+}
+```
+
+Notes:
+
+- The provenance is that of the **installed library the benchmark loaded**, not of this
+  benchmark module's checkout — that is the commit the measurement is actually about.
+  Run `.\mvnw -DskipTests install` before each run (as always) so the stamped commit
+  matches the code you measured.
+- `git.dirty: true` means the measured jar was built from a working tree with uncommitted
+  changes, so the commit hash alone does not fully identify the code — treat such a
+  baseline as provisional.
+- The step is idempotent (re-stamping refreshes the provenance and keeps the results) and
+  fails loudly if the jar carries no provenance; pass `-AllowMissing` to stamp anyway with
+  `available: false`. See the script header (`Get-Help .\benchmarks\stamp-provenance.ps1`)
+  for all options.
+- **Consumers must read the results under the `results` key** now (e.g. a comparison
+  script does `json.load(...)["results"]`), since the top level is an object rather than a
+  bare array.
 
 **Critical rule:** the benchmark code must be **identical** on both sides — only the
 library may differ. So when comparing an optimization branch (e.g.

--- a/benchmarks/stamp-provenance.ps1
+++ b/benchmarks/stamp-provenance.ps1
@@ -1,0 +1,218 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+    Stamps a JMH JSON result file with the Git provenance of the slf4j-toys
+    library it measured, so a benchmark baseline can be traced back to the exact
+    commit it was run against.
+
+.DESCRIPTION
+    JMH's JSON output is a plain top-level array of per-benchmark result objects,
+    with no slot for run-level metadata. This script wraps that array into
+
+        {
+          "provenance": { ...git.* ..., "available": true, ... },
+          "results":    [ <the original JMH array, unchanged> ]
+        }
+
+    The provenance is read from META-INF/git.properties inside the *measured*
+    library jar (the same SNAPSHOT the benchmark module resolved from the local
+    Maven repository), falling back to the jar manifest's SCM-* entries. Because
+    the benchmarks always measure the installed library, that jar's commit - not
+    this benchmark module's own checkout - is the meaningful provenance.
+
+    Typical use, right after JMH has written its result file:
+
+        .\mvnw -DskipTests install
+        .\mvnw -f benchmarks\pom.xml compile exec:java "-Dexec.args=... -rf json -rff after.json"
+        .\benchmarks\stamp-provenance.ps1 after.json
+
+    The results array is embedded verbatim (as text), so numbers and formatting
+    are preserved byte-for-byte. The operation is idempotent: re-stamping an
+    already-wrapped file refreshes the provenance block and keeps the results.
+
+.PARAMETER JsonPath
+    Path to the JMH result JSON to stamp. Rewritten in place unless -OutPath is
+    given.
+
+.PARAMETER JarPath
+    Explicit path to the measured library jar. When omitted, the jar is located
+    in the local Maven repository from the slf4j-toys dependency version declared
+    in the benchmarks POM.
+
+.PARAMETER PomPath
+    Path to the benchmarks POM used to resolve the library version. Defaults to
+    pom.xml next to this script.
+
+.PARAMETER OutPath
+    Write the stamped JSON here instead of overwriting JsonPath.
+
+.PARAMETER AllowMissing
+    Stamp with provenance.available = false instead of failing when no provenance
+    is found in the jar (e.g. a library built before the provenance feature, or
+    built on a machine without git).
+
+.EXAMPLE
+    .\benchmarks\stamp-provenance.ps1 after.json
+
+.EXAMPLE
+    .\benchmarks\stamp-provenance.ps1 -JsonPath raw.json -OutPath after-stamped.json
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)][string]$JsonPath,
+    [string]$JarPath,
+    [string]$PomPath,
+    [string]$OutPath,
+    [switch]$AllowMissing
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-LibraryJar {
+    param([string]$PomPath)
+
+    [xml]$pom = Get-Content -Raw -LiteralPath $PomPath
+    $ns = @{ m = 'http://maven.apache.org/POM/4.0.0' }
+    $dep = Select-Xml -Xml $pom -Namespace $ns `
+        -XPath "//m:dependencies/m:dependency[m:groupId='org.usefultoys' and m:artifactId='slf4j-toys']" |
+        Select-Object -First 1
+    if (-not $dep) {
+        throw "Could not find the org.usefultoys:slf4j-toys dependency in $PomPath"
+    }
+    $version = $dep.Node.version
+    $repo = if ($env:MAVEN_REPO) { $env:MAVEN_REPO } else { Join-Path $HOME '.m2/repository' }
+    $jar = Join-Path $repo "org/usefultoys/slf4j-toys/$version/slf4j-toys-$version.jar"
+    if (-not (Test-Path -LiteralPath $jar)) {
+        throw "Measured library jar not found: $jar`n" +
+              "Install it first from the library you want to measure: .\mvnw -DskipTests install"
+    }
+    return $jar
+}
+
+function Read-JarEntry {
+    param([string]$JarPath, [string]$EntryName)
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($JarPath)
+    try {
+        $entry = $zip.GetEntry($EntryName)
+        if (-not $entry) { return $null }
+        $reader = New-Object System.IO.StreamReader($entry.Open())
+        try { return $reader.ReadToEnd() } finally { $reader.Dispose() }
+    } finally {
+        $zip.Dispose()
+    }
+}
+
+# Reads git.properties (preferred) or, failing that, the SCM-* manifest entries
+# from the measured jar. Returns an ordered map of raw string key/value pairs and
+# a label describing which source was used.
+function Get-Provenance {
+    param([string]$JarPath)
+
+    $prov = [ordered]@{}
+    $source = $null
+
+    $gitProps = Read-JarEntry -JarPath $JarPath -EntryName 'META-INF/git.properties'
+    if ($gitProps) {
+        foreach ($line in ($gitProps -split "`r?`n")) {
+            if ($line -match '^\s*#' -or $line -notmatch '=') { continue }
+            $parts = $line -split '=', 2
+            $k = $parts[0].Trim()
+            $v = $parts[1].Trim()
+            if ($k) { $prov[$k] = $v }
+        }
+        if ($prov.Count -gt 0) { $source = 'META-INF/git.properties' }
+    }
+
+    if ($prov.Count -eq 0) {
+        $mf = Read-JarEntry -JarPath $JarPath -EntryName 'META-INF/MANIFEST.MF'
+        if ($mf) {
+            foreach ($line in ($mf -split "`r?`n")) {
+                if ($line -match '^(SCM-[^:]+):\s*(.*)$') {
+                    $prov[$Matches[1]] = $Matches[2].Trim()
+                }
+            }
+            if ($prov.Count -gt 0) { $source = 'META-INF/MANIFEST.MF (SCM-*)' }
+        }
+    }
+
+    return @{ Values = $prov; Source = $source }
+}
+
+# ---- resolve inputs -------------------------------------------------------
+
+if (-not (Test-Path -LiteralPath $JsonPath)) {
+    throw "JMH result file not found: $JsonPath"
+}
+if (-not $PomPath) {
+    $PomPath = Join-Path $PSScriptRoot 'pom.xml'
+}
+if (-not $JarPath) {
+    $JarPath = Resolve-LibraryJar -PomPath $PomPath
+}
+if (-not (Test-Path -LiteralPath $JarPath)) {
+    throw "Measured library jar not found: $JarPath"
+}
+
+# ---- read provenance from the measured jar --------------------------------
+
+$read = Get-Provenance -JarPath $JarPath
+$provRaw = $read.Values
+if ($provRaw.Count -eq 0 -and -not $AllowMissing) {
+    throw "No provenance found in $JarPath (neither META-INF/git.properties nor SCM-* " +
+          "manifest entries).`nRebuild/reinstall the library at a commit that carries " +
+          "provenance (.\mvnw -DskipTests install), or pass -AllowMissing to stamp anyway."
+}
+
+$provenance = [ordered]@{}
+$provenance['available']    = ($provRaw.Count -gt 0)
+$provenance['source']       = "$(Split-Path -Leaf $JarPath)$(if ($read.Source) { " ($($read.Source))" })"
+$provenance['stampedAtUtc'] = (Get-Date).ToUniversalTime().ToString('o')
+foreach ($k in $provRaw.Keys) {
+    $v = $provRaw[$k]
+    if ($k -eq 'git.dirty' -and ($v -eq 'true' -or $v -eq 'false')) {
+        $provenance[$k] = ($v -eq 'true')
+    } else {
+        $provenance[$k] = $v
+    }
+}
+
+# ---- extract the JMH results array as text --------------------------------
+
+$raw = (Get-Content -Raw -LiteralPath $JsonPath).Trim()
+if ($raw.StartsWith('[')) {
+    # Plain JMH output: embed the array verbatim to preserve every value exactly.
+    $resultsText = $raw
+} elseif ($raw.StartsWith('{')) {
+    # Already wrapped by a previous run: re-stamp, keeping the results.
+    $obj = $raw | ConvertFrom-Json -Depth 200
+    if (-not ($obj.PSObject.Properties.Name -contains 'results')) {
+        throw "$JsonPath is a JSON object without a 'results' array; refusing to overwrite it."
+    }
+    $resultsText = $obj.results | ConvertTo-Json -Depth 200
+} else {
+    throw "$JsonPath does not look like JMH JSON output (expected a leading '[' or '{')."
+}
+
+# ---- compose the wrapped document -----------------------------------------
+
+$provJson = ($provenance | ConvertTo-Json -Depth 5)
+$provIndented    = ($provJson    -split "`r?`n") -join "`n  "
+$resultsIndented = ($resultsText -split "`r?`n") -join "`n  "
+
+$out = "{`n  ""provenance"": $provIndented,`n  ""results"": $resultsIndented`n}`n"
+
+$target = if ($OutPath) { $OutPath } else { $JsonPath }
+Set-Content -LiteralPath $target -Value $out -Encoding utf8 -NoNewline
+
+# Status summary goes to the information stream (not stdout), so it stays visible
+# without polluting any pipeline that captures the script's output.
+Write-Information "Stamped $target with library provenance:" -InformationAction Continue
+foreach ($entry in $provenance.GetEnumerator()) {
+    Write-Information ("  {0,-22} {1}" -f $entry.Key, $entry.Value) -InformationAction Continue
+}
+if (-not $provenance['available']) {
+    Write-Warning "Provenance was NOT available in the measured jar; recorded available=false."
+}


### PR DESCRIPTION
## Context

The `benchmarks/` module writes JMH results with `-rf json`. Those baselines are
kept and compared before/after a change (see `benchmarks/README.md`). Every jar
the build produces is already stamped with git provenance
(`META-INF/git.properties` plus `SCM-*` manifest entries, added in
`build(build): stamp every jar with git commit/branch provenance`).

## Problem

A JMH result file is a plain top-level array of result objects, with no record
of **which slf4j-toys commit produced the numbers**:

```json
[ { "benchmark": "...create", "primaryMetric": { "score": 288.29 } }, ... ]
```

Comparing two stored baselines tells you *what* changed but not *between which
two commits* ❌ — so a saved before/after pair slowly loses meaning, and a
baseline handed over later is unattributable.

## Solution

A post-processing step folds the measured library's provenance into the result
file. **`benchmarks/stamp-provenance.ps1`**:

- reads `META-INF/git.properties` (falling back to the `SCM-*` manifest entries)
  from the **measured** library jar, resolved out of the local Maven repository
  from the version in `benchmarks/pom.xml` — i.e. the commit the benchmark
  actually loaded, not this module's own checkout;
- wraps the JMH array into `{ "provenance": {...}, "results": [...] }`, embedding
  the results **verbatim as text** so every score keeps full precision;
- is **idempotent** (re-stamping refreshes provenance, keeps results) and **fails
  loudly** when the jar carries no provenance (`-AllowMissing` overrides with
  `available: false`).

Provenance is deliberately that of the installed library, since that is the code
the measurement is about; `git.dirty: true` flags a baseline built from an
uncommitted tree as provisional.

## API Changes

No library API change. **Result-file format change** (tooling only): stamped
files are a JSON object with the JMH array under `results`, not a bare array, so
comparison consumers must read `data["results"]`. Documented in the README.

## Code Changes

Production/tooling:
- `benchmarks/stamp-provenance.ps1` (new) — the stamping script.
- `benchmarks/README.md` — documents the step in the before/after workflow and
  the `results`-key change.

No Java sources touched; the `benchmarks/` module is not part of the Maven
reactor.

## Test Results

Exercised end-to-end against a real 1.6 MB JMH result file (174 benchmark
records), after `mvnw -DskipTests install` produced a provenance-stamped jar:

- Output is valid JSON with top-level `provenance` + `results`.
- `results` is byte-for-byte equal to the original array; sample score retains
  full precision (`288.29267918977087`).
- `git.dirty` serialized as a JSON boolean; provenance auto-sourced from the
  correct jar without `-JarPath`.
- Idempotent: re-stamping keeps a single `provenance` block and intact `results`.
- Missing-provenance jar → fails with a clear remediation message; `-AllowMissing`
  → stamps with `available: false` and a warning.

The Java test suite was not run: this change touches only the non-reactor
`benchmarks/` tooling and its README, with no effect on library code; CI
(`maven-build-test.yml`) confirms the library build is unaffected.

## Examples

```powershell
.\mvnw -DskipTests install
.\mvnw -f benchmarks\pom.xml compile exec:java "-Dexec.args=MeterOperationBenchmark -prof gc -rf json -rff after.json"
.\benchmarks\stamp-provenance.ps1 after.json
```

```json
{
  "provenance": {
    "available": true,
    "source": "slf4j-toys-2.1.0-SNAPSHOT.jar (META-INF/git.properties)",
    "git.commit.id.abbrev": "9926b411",
    "git.branch": "main",
    "git.dirty": false,
    "git.commit.id.describe": "2.0.0-145-g9926b411"
  },
  "results": [ "the original JMH array, unchanged" ]
}
```

---

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
