### PR TITLE
Harden UnitFormatter's array-length contract and document edge cases

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
@@ -86,6 +86,13 @@ public final class UnitFormatter {
      *
      * <p>Negative values are not supported and are rendered as "?" followed by the base unit.
      *
+     * <p>Unlike {@link #doubleUnit}, a value that fits in the base unit is rendered as a plain integer
+     * with no decimal point (e.g. {@code "500ns"}), because an integer count of the base unit is exact
+     * and a trailing {@code ".0"} would add noise without adding information. {@code doubleUnit} cannot
+     * take the same shortcut since a double is never known to be an exact integer count. This asymmetry
+     * is intentional and covered by tests in {@code UnitFormatterTest}; do not "simplify" by merging the
+     * two methods into one shared implementation without preserving it.
+     *
      * @param sb The StringBuilder that receives the formatted representation.
      * @param value The long integer value to format.
      * @param units An array of unit strings (e.g., "B", "kB", "MB"). Must have exactly one more element
@@ -100,6 +107,9 @@ public final class UnitFormatter {
             return;
         }
 
+        // Fast path: below the first factor's rounding threshold, render as a plain integer. This is not
+        // just a perf shortcut - skipping it would route base-unit values through appendScaledDecimal and
+        // print a spurious ".0" (see class-level asymmetry note above).
         int index = 0;
         final int limit = factors[index] + factors[index] / 10;
         if (value < limit) {
@@ -129,6 +139,11 @@ public final class UnitFormatter {
      *
      * <p>Negative values, {@code NaN} and infinite values are not supported and are rendered as "?"
      * followed by the base unit.
+     *
+     * <p>Unlike {@link #longUnit(StringBuilder, long, String[], int[])}, values that fit in the base unit
+     * are still rendered with a decimal point (e.g. {@code "500.0ns"}): a {@code double} is never known
+     * to represent an exact integer count, so there is no equivalent fast path here. This asymmetry is
+     * intentional and covered by tests in {@code UnitFormatterTest}.
      *
      * @param sb The StringBuilder that receives the formatted representation.
      * @param value The double value to format.

--- a/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
@@ -62,7 +62,9 @@ public final class UnitFormatter {
      * <p>Negative values are not supported and are rendered as "?" followed by the base unit.
      *
      * @param value The long integer value to format.
-     * @param units An array of unit strings (e.g., "B", "kB", "MB").
+     * @param units An array of unit strings (e.g., "B", "kB", "MB"). Must have exactly one more element
+     *              than {@code factors}, i.e. {@code units.length == factors.length + 1}: the extra
+     *              element is the top tier reached once the value has been scaled down by every factor.
      * @param factors An array of factors for unit conversion (e.g., 1000, 1000, 1000).
      * @return A formatted string representing the value with units, or "?" followed by the base unit
      *         when the value is negative.
@@ -82,7 +84,9 @@ public final class UnitFormatter {
      *
      * @param sb The StringBuilder that receives the formatted representation.
      * @param value The long integer value to format.
-     * @param units An array of unit strings (e.g., "B", "kB", "MB").
+     * @param units An array of unit strings (e.g., "B", "kB", "MB"). Must have exactly one more element
+     *              than {@code factors}, i.e. {@code units.length == factors.length + 1}: the extra
+     *              element is the top tier reached once the value has been scaled down by every factor.
      * @param factors An array of factors for unit conversion (e.g., 1000, 1000, 1000).
      */
     @SuppressWarnings("AssignmentToMethodParameter")
@@ -124,7 +128,9 @@ public final class UnitFormatter {
      *
      * @param sb The StringBuilder that receives the formatted representation.
      * @param value The double value to format.
-     * @param units An array of unit strings (e.g., "/s", "k/s", "M/s").
+     * @param units An array of unit strings (e.g., "/s", "k/s", "M/s"). Must have exactly one more element
+     *              than {@code factors}, i.e. {@code units.length == factors.length + 1}: the extra
+     *              element is the top tier reached once the value has been scaled down by every factor.
      * @param factors An array of factors for unit conversion (e.g., 1000, 1000, 1000).
      */
     @SuppressWarnings("AssignmentToMethodParameter")

--- a/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
+++ b/src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java
@@ -46,6 +46,10 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public final class UnitFormatter {
 
+    // Package-visible only so unit tests can assert their lengths (see UnitFormatterTest). Element
+    // mutation is not defensively prevented: wrapping these in an immutable collection would require
+    // boxing the primitive int[] factors, defeating the allocation-free hot-path goal documented above.
+    // Do not mutate array contents at runtime; treat them as if declared immutable.
     final int[] TIME_FACTORS = {1000, 1000, 1000, 60, 60};
     final String[] TIME_UNITS = {"ns", "us", "ms", "s", "m", "h"};
     final String[] MEMORY_UNITS = {"B", "kB", "MB", "GB"};

--- a/src/test/java/org/usefultoys/slf4j/utils/UnitFormatterTest.java
+++ b/src/test/java/org/usefultoys/slf4j/utils/UnitFormatterTest.java
@@ -36,7 +36,10 @@ import static org.junit.jupiter.params.provider.Arguments.of;
  * <p>
  * <b>Coverage:</b>
  * <ul>
- *   <li><b>Custom Units:</b> Tests formatting of long and double values with custom unit arrays</li>
+ *   <li><b>Custom Units:</b> Tests formatting of long and double values with custom unit arrays. The local
+ *       {@code UNITS}/{@code FACTORS} fixture follows the same {@code units.length == factors.length + 1}
+ *       invariant as the production arrays (see {@code shouldMaintainUnitArrayLengthInvariant}), and includes
+ *       a case that reaches the top unit tier ("D") to exercise that invariant</li>
  *   <li><b>Byte Units:</b> Verifies formatting of byte values with appropriate units (B, KB, MB, etc.)</li>
  *   <li><b>Time Units:</b> Covers formatting of time values in nanoseconds, microseconds, milliseconds, seconds</li>
  *   <li><b>Iteration Units:</b> Tests formatting of iteration counts with appropriate units, including G suffix for large values and M-to-G boundary transition</li>
@@ -53,7 +56,7 @@ import static org.junit.jupiter.params.provider.Arguments.of;
 class UnitFormatterTest {
 
     private static final int[] FACTORS = {1000, 1000, 1000};
-    private static final String[] UNITS = {"A", "B", "C"};
+    private static final String[] UNITS = {"A", "B", "C", "D"};
 
     static Stream<org.junit.jupiter.params.provider.Arguments> provideLongUnitTestCases() {
         return Stream.of(
@@ -92,7 +95,9 @@ class UnitFormatterTest {
             of(5050L, "5.1B"),
             of(999900L, "999.9B"),
             of(1000000L, "1000.0B"),
-            of(1100000L, "1.1C")
+            of(1100000L, "1.1C"),
+            of(1099000000L, "1099.0C"),
+            of(1100000000L, "1.1D")
         );
     }
 
@@ -168,7 +173,9 @@ class UnitFormatterTest {
             of(5050L, "5.1B"),
             of(999900L, "999.9B"),
             of(1000000L, "1000.0B"),
-            of(1100000L, "1.1C")
+            of(1100000L, "1.1C"),
+            of(1099000000L, "1099.0C"),
+            of(1100000000L, "1.1D")
         );
     }
 


### PR DESCRIPTION
## Context

`UnitFormatter` (`org.usefultoys.slf4j.utils`) recently went through cleanup (#98-ish: removing unused `String`-returning overloads, adding `append*` coverage). This PR is a follow-up excellence review of that same class and its test suite, focused on hardening the implicit contract between `longUnit`/`doubleUnit` and the `units`/`factors` arrays they take, without changing any observable behavior.

## Problem

`longUnit`/`doubleUnit` index into `units[index]` where `index` can reach `factors.length` once a value has been scaled through every tier — so callers must always pass `units.length == factors.length + 1`. Production constants (`MEMORY_UNITS`/`MEMORY_FACTORS`, `TIME_UNITS`/`TIME_FACTORS`, ...) all honor this and it's asserted by `shouldMaintainUnitArrayLengthInvariant()`, but three things were missing:

- ❌ `UnitFormatterTest`'s own local `UNITS`/`FACTORS` fixture (used by the generic `longUnit`/`doubleUnit` parametrized tests) had `UNITS.length == FACTORS.length` (3/3) instead of the required 4/3 — the tests only passed because no tested value pushed the scaling index far enough to need the missing top-tier unit, silently masking the method's real contract and leaving a latent `ArrayIndexOutOfBoundsException` risk for any future boundary case.
- ❌ The invariant itself was undocumented in `longUnit`/`doubleUnit`'s Javadoc — nothing in the method contract told a future maintainer adding a new unit family what shape the arrays must have.
- ❌ Two other implementation details were true but unexplained: the unit/factor arrays are mutable primitive arrays with package visibility (no defensive copy), and `longUnit` intentionally omits the decimal point for base-unit values (`"500ns"`) while `doubleUnit` always includes one (`"500.0ns"`) — a distinction a future refactor merging the two structurally-similar methods could easily drop without noticing.

## Solution

- **Test fixture**: extended `UnitFormatterTest`'s local `UNITS` array to 4 elements ("A","B","C","D") to match the invariant, and added parametrized cases (`1_099_000_000L -> "1099.0C"`, `1_100_000_000L -> "1.1D"`) to both the `longUnit` and `doubleUnit` generic test methods so the top unit tier is actually exercised.
- **Contract documentation**: added the `units.length == factors.length + 1` precondition to the `@param units` Javadoc of all three `longUnit`/`doubleUnit` overloads.
- **Mutability warning**: added a comment above the `TIME_FACTORS`/`TIME_UNITS`/... field block explaining why they're package-visible (test access) and why they aren't wrapped as immutable (would require boxing the primitive `int[]`, against the class's documented allocation-free hot-path goal), making the "don't mutate" expectation explicit.
- **Asymmetry documentation**: added Javadoc notes to `longUnit`/`doubleUnit` explaining why `longUnit` has a decimal-free fast path for base-unit values and `doubleUnit` doesn't, warning against merging the two implementations without preserving it.

No production code behavior changes — this is test-fixture hardening plus documentation/comments.

## Code Changes

- `src/test/java/org/usefultoys/slf4j/utils/UnitFormatterTest.java` — fixture fix + 4 new parametrized cases, updated class-level coverage Javadoc
- `src/main/java/org/usefultoys/slf4j/utils/UnitFormatter.java` — Javadoc/comment-only changes across 3 commits (array-length invariant, mutability warning, decimal-format asymmetry)

4 commits, one per finding, each independently buildable and tested.

## Test Results

- `UnitFormatterTest`: 203/203 passing (includes the 4 new boundary cases)
- Full core tier (`.\mvnw test`): 3202/3202 passing, 0 failures/errors
- Full with-logback tier (`.\mvnw test -P slf4j-2.0,with-logback`): 75/75 additional logback-specific tests passing, 0 failures/errors

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
