### PR TITLE
Unify Javadoc and structure across Session and *Config classes

### DIFF
--- a/src/main/java/org/usefultoys/slf4j/SessionConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/SessionConfig.java
@@ -74,9 +74,7 @@ public class SessionConfig {
      * {@code 2}, and values above {@link #UUID_LENGTH} are clamped to {@link #UUID_LENGTH}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.session.print.uuid.size}, defaulting to {@code 6}.
-     * <p>
-     * <strong>Thread Safety:</strong> This field can be modified at runtime, but caution is advised in concurrent
-     * environments as changes are not synchronized.
+     * Can be changed at runtime.
      */
     public int uuidSize = 6;
 
@@ -84,10 +82,7 @@ public class SessionConfig {
      * The character encoding used for logging and string operations.
      * <p>
      * The value is read from the system property {@code slf4jtoys.session.print.charset}, defaulting to the
-     * JVM's default charset.
-     * <p>
-     * <strong>Thread Safety:</strong> This field can be modified at runtime, but caution is advised in concurrent
-     * environments as changes are not synchronized.
+     * JVM's default charset. Can be changed at runtime.
      */
     public String charset = Charset.defaultCharset().name();
 
@@ -105,10 +100,7 @@ public class SessionConfig {
      * <p>
      * The value is read from the system property {@code slf4jtoys.session.print.locale}, which must be a
      * BCP 47 language tag (e.g., {@code "en-US"}, {@code "de-DE"}) as accepted by
-     * {@link Locale#forLanguageTag(String)}, defaulting to the JVM's default locale.
-     * <p>
-     * <strong>Thread Safety:</strong> This field can be modified at runtime, but caution is advised in concurrent
-     * environments as changes are not synchronized.
+     * {@link Locale#forLanguageTag(String)}, defaulting to the JVM's default locale. Can be changed at runtime.
      */
     public Locale locale = Locale.getDefault();
 

--- a/src/main/java/org/usefultoys/slf4j/SystemConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/SystemConfig.java
@@ -88,8 +88,12 @@ public class SystemConfig {
     public boolean usePlatformManagedBean;
 
     /**
-     * Initializes the configuration properties. This method should be called at application startup to ensure
-     * consistent behavior.
+     * Initializes the configuration properties by reading values from system properties.
+     * <p>
+     * This method is automatically called in a static initializer when the class is first loaded.
+     * It can also be called manually to reload configuration from system properties after they have been modified.
+     * <p>
+     * For consistent behavior, ensure system properties are set before this class is first accessed.
      */
     public void init() {
         useMemoryManagedBean = ConfigParser.getBooleanProperty(PROP_USE_MEMORY_MANAGED_BEAN, false);

--- a/src/main/java/org/usefultoys/slf4j/SystemConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/SystemConfig.java
@@ -55,35 +55,35 @@ public class SystemConfig {
      * Determines whether memory usage metrics are retrieved from the {@link java.lang.management.MemoryMXBean}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.useMemoryManagedBean}, defaulting to {@code false}.
-     * It can be changed at runtime.
+     * Can be changed at runtime.
      */
     public boolean useMemoryManagedBean;
     /**
      * Determines whether class loading metrics are retrieved from the {@link java.lang.management.ClassLoadingMXBean}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.useClassLoadingManagedBean}, defaulting to {@code false}.
-     * It can be changed at runtime.
+     * Can be changed at runtime.
      */
     public boolean useClassLoadingManagedBean;
     /**
      * Determines whether JIT compiler metrics are retrieved from the {@link java.lang.management.CompilationMXBean}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.useCompilationManagedBean}, defaulting to {@code false}.
-     * It can be changed at runtime.
+     * Can be changed at runtime.
      */
     public boolean useCompilationManagedBean;
     /**
      * Determines whether garbage collection metrics are retrieved from the {@link java.lang.management.GarbageCollectorMXBean}s.
      * <p>
      * The value is read from the system property {@code slf4jtoys.useGarbageCollectionManagedBean}, defaulting to {@code false}.
-     * It can be changed at runtime.
+     * Can be changed at runtime.
      */
     public boolean useGarbageCollectionManagedBean;
     /**
      * Determines whether operating system metrics are retrieved from the {@link java.lang.management.OperatingSystemMXBean}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.usePlatformManagedBean}, defaulting to {@code false}.
-     * It can be changed at runtime.
+     * Can be changed at runtime.
      */
     public boolean usePlatformManagedBean;
 

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -226,8 +226,12 @@ public class MeterConfig {
     public String messageSuffix;
 
     /**
-     * Initializes the configuration attributes by reading the corresponding system properties.
-     * This method should be called at application startup to ensure they are properly initialized.
+     * Initializes the configuration properties by reading values from system properties.
+     * <p>
+     * This method is automatically called in a static initializer when the class is first loaded.
+     * It can also be called manually to reload configuration from system properties after they have been modified.
+     * <p>
+     * For consistent behavior, ensure system properties are set before this class is first accessed.
      */
     public void init() {
         progressPeriodMilliseconds = ConfigParser.getMillisecondsProperty(PROP_PROGRESS_PERIOD, 2000L);

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -46,30 +46,30 @@ public class MeterConfig {
     }
 
     // System property keys
-    /** System property key for the message logger name suffix. */
-    public final String PROP_MESSAGE_SUFFIX = "slf4jtoys.meter.message.suffix";
-    /** System property key for the message logger name prefix. */
-    public final String PROP_MESSAGE_PREFIX = "slf4jtoys.meter.message.prefix";
-    /** System property key for the data logger name suffix. */
-    public final String PROP_DATA_SUFFIX = "slf4jtoys.meter.data.suffix";
-    /** System property key for the data logger name prefix. */
-    public final String PROP_DATA_PREFIX = "slf4jtoys.meter.data.prefix";
-    /** System property key for enabling/disabling memory printing in readable messages. */
-    public final String PROP_PRINT_MEMORY = "slf4jtoys.meter.print.memory";
-    /** System property key for enabling/disabling category printing in readable messages. */
-    public final String PROP_PRINT_CATEGORY = "slf4jtoys.meter.print.category";
-    /** System property key for enabling/disabling CPU load printing in readable messages. */
-    public final String PROP_PRINT_LOAD = "slf4jtoys.meter.print.load";
     /** System property key for the progress reporting period. */
     public final String PROP_PROGRESS_PERIOD = "slf4jtoys.meter.progress.period";
-    /** System property key for enabling/disabling position printing in readable messages. */
-    public final String PROP_PRINT_POSITION = "slf4jtoys.meter.print.position";
+    /** System property key for enabling/disabling category printing in readable messages. */
+    public final String PROP_PRINT_CATEGORY = "slf4jtoys.meter.print.category";
     /** System property key for enabling/disabling status printing in readable messages. */
     public final String PROP_PRINT_STATUS = "slf4jtoys.meter.print.status";
+    /** System property key for enabling/disabling position printing in readable messages. */
+    public final String PROP_PRINT_POSITION = "slf4jtoys.meter.print.position";
+    /** System property key for enabling/disabling CPU load printing in readable messages. */
+    public final String PROP_PRINT_LOAD = "slf4jtoys.meter.print.load";
+    /** System property key for enabling/disabling memory printing in readable messages. */
+    public final String PROP_PRINT_MEMORY = "slf4jtoys.meter.print.memory";
     /** System property key for enabling/disabling the forgotten-meter leak detector. */
     public final String PROP_DETECT_LEAKS = "slf4jtoys.meter.detect.leaks";
     /** System property key for the shared unknown-meter misuse-report throttle interval. */
     public final String PROP_NOOP_REPORT_INTERVAL = "slf4jtoys.meter.noop.report.interval";
+    /** System property key for the data logger name prefix. */
+    public final String PROP_DATA_PREFIX = "slf4jtoys.meter.data.prefix";
+    /** System property key for the data logger name suffix. */
+    public final String PROP_DATA_SUFFIX = "slf4jtoys.meter.data.suffix";
+    /** System property key for the message logger name prefix. */
+    public final String PROP_MESSAGE_PREFIX = "slf4jtoys.meter.message.prefix";
+    /** System property key for the message logger name suffix. */
+    public final String PROP_MESSAGE_SUFFIX = "slf4jtoys.meter.message.suffix";
 
     /**
      * The minimum time interval (in milliseconds) between consecutive progress status reports.

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -35,7 +35,6 @@ import org.usefultoys.slf4j.utils.ConfigParser;
  * This is a utility class and is not meant to be instantiated.
  *
  * @author Daniel Felix Ferber
- * @author Co-authored-by: GitHub Copilot using Claude Sonnet 4.5
  * @see Meter
  * @see MeterData
  */

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -41,7 +41,11 @@ import org.usefultoys.slf4j.utils.ConfigParser;
  */
 @UtilityClass
 public class MeterConfig {
+    static {
+        init();
+    }
 
+    // System property keys
     /** System property key for the message logger name suffix. */
     public final String PROP_MESSAGE_SUFFIX = "slf4jtoys.meter.message.suffix";
     /** System property key for the message logger name prefix. */
@@ -66,10 +70,6 @@ public class MeterConfig {
     public final String PROP_DETECT_LEAKS = "slf4jtoys.meter.detect.leaks";
     /** System property key for the shared unknown-meter misuse-report throttle interval. */
     public final String PROP_NOOP_REPORT_INTERVAL = "slf4jtoys.meter.noop.report.interval";
-
-    static {
-        init();
-    }
 
     /**
      * The minimum time interval (in milliseconds) between consecutive progress status reports.

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -171,6 +171,8 @@ public class MeterConfig {
      * Setting a non-empty prefix or suffix (see also {@link #dataSuffix}) adds a small initialization cost to
      * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
      * the category logger as-is.
+     * <p>
+     * Can be changed at runtime.
      */
     public String dataPrefix;
 
@@ -188,6 +190,8 @@ public class MeterConfig {
      * Setting a non-empty prefix (see also {@link #dataPrefix}) or suffix adds a small initialization cost to
      * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
      * the category logger as-is.
+     * <p>
+     * Can be changed at runtime.
      */
     public String dataSuffix;
 
@@ -205,6 +209,8 @@ public class MeterConfig {
      * Setting a non-empty prefix or suffix (see also {@link #messageSuffix}) adds a small initialization cost to
      * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
      * the category logger as-is.
+     * <p>
+     * Can be changed at runtime.
      */
     public String messagePrefix;
 
@@ -222,6 +228,8 @@ public class MeterConfig {
      * Setting a non-empty prefix (see also {@link #messagePrefix}) or suffix adds a small initialization cost to
      * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
      * the category logger as-is.
+     * <p>
+     * Can be changed at runtime.
      */
     public String messageSuffix;
 

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -269,8 +269,8 @@ public class MeterConfig {
     }
 
     /**
-     * Resets all configuration properties to their default values.
-     * This method is useful for testing purposes or when reinitializing the configuration.
+     * Resets the configuration properties to their default values.
+     * This method is useful for testing or re-initializing the configuration.
      * <p>
      * Also resets the shared unknown-meter misuse-report throttle's runtime state (next-allowed-report
      * timestamp and suppressed-report count) back to its initial, unthrottled state, so tests relying on

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -74,49 +74,49 @@ public class MeterConfig {
     /**
      * The minimum time interval (in milliseconds) between consecutive progress status reports.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.progress.period}, defaulting to {@code 2000} (2 seconds).
+     * The value is read from the system property {@code slf4jtoys.meter.progress.period}, defaulting to {@code 2000} (2 seconds).
      * The value can be suffixed with {@code ms}, {@code s}, {@code m}, or {@code h}.
-     * Can be assigned a new value at runtime.
+     * Can be changed at runtime.
      */
     public long progressPeriodMilliseconds;
 
     /**
      * Whether the {@link Meter} includes the category in its human-readable messages.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.print.category}, defaulting to {@code false}.
-     * Can be assigned a new value at runtime.
+     * The value is read from the system property {@code slf4jtoys.meter.print.category}, defaulting to {@code false}.
+     * Can be changed at runtime.
      */
     public boolean printCategory;
 
     /**
      * Whether the {@link Meter} includes the operation's status (e.g., OK, FAIL) in its human-readable messages.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.print.status}, defaulting to {@code true}.
-     * Can be assigned a new value at runtime.
+     * The value is read from the system property {@code slf4jtoys.meter.print.status}, defaulting to {@code true}.
+     * Can be changed at runtime.
      */
     public boolean printStatus;
 
     /**
      * Whether the {@link Meter} includes the operation's position (event counter) in its human-readable messages.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.print.position}, defaulting to {@code false}.
-     * Can be assigned a new value at runtime.
+     * The value is read from the system property {@code slf4jtoys.meter.print.position}, defaulting to {@code false}.
+     * Can be changed at runtime.
      */
     public boolean printPosition;
 
     /**
      * Whether the {@link Meter} includes the system CPU load in its human-readable messages.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.print.load}, defaulting to {@code false}.
-     * Can be assigned a new value at runtime.
+     * The value is read from the system property {@code slf4jtoys.meter.print.load}, defaulting to {@code false}.
+     * Can be changed at runtime.
      */
     public boolean printLoad;
 
     /**
      * Whether the {@link Meter} includes memory usage information in its human-readable messages.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.print.memory}, defaulting to {@code false}.
-     * Can be assigned a new value at runtime.
+     * The value is read from the system property {@code slf4jtoys.meter.print.memory}, defaulting to {@code false}.
+     * Can be changed at runtime.
      */
     public boolean printMemory;
 
@@ -130,8 +130,8 @@ public class MeterConfig {
      * Disable this flag in test environments where meters are intentionally left open, or when the
      * overhead of registering each started meter is undesirable.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.detect.leaks}, defaulting to {@code true}.
-     * Can be assigned a new value at runtime, but doing so only affects <em>new</em> registrations: a
+     * The value is read from the system property {@code slf4jtoys.meter.detect.leaks}, defaulting to {@code true}.
+     * Can be changed at runtime, but doing so only affects <em>new</em> registrations: a
      * {@link Meter} started while this flag was {@code true} remains registered and can still be reported
      * as a leak after the flag is set back to {@code false}, since disabling it does not retroactively
      * deregister or discard already-pending reports.
@@ -151,9 +151,9 @@ public class MeterConfig {
      * {@code 0} disables throttling: every occurrence is reported. A negative value disables reporting
      * entirely: no misuse against the shared instance is ever logged.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.noop.report.interval}, defaulting to
+     * The value is read from the system property {@code slf4jtoys.meter.noop.report.interval}, defaulting to
      * {@code 60000} (1 minute). The value can be suffixed with {@code ms}, {@code s}, {@code m}, or
-     * {@code h}. Can be assigned a new value at runtime.
+     * {@code h}. Can be changed at runtime.
      */
     public long noopReportIntervalMilliseconds;
 
@@ -166,7 +166,7 @@ public class MeterConfig {
      * Example: With prefix {@code "data."}, a logger {@code "a.b.c.MyClass"} becomes {@code "data.a.b.c.MyClass"}
      * for encoded data.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.data.prefix}, defaulting to an empty string.
+     * The value is read from the system property {@code slf4jtoys.meter.data.prefix}, defaulting to an empty string.
      * <p>
      * Setting a non-empty prefix or suffix (see also {@link #dataSuffix}) adds a small initialization cost to
      * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
@@ -183,7 +183,7 @@ public class MeterConfig {
      * Example: With suffix {@code ".data"}, a logger {@code "a.b.c.MyClass"} becomes {@code "a.b.c.MyClass.data"}
      * for encoded data.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.data.suffix}, defaulting to an empty string.
+     * The value is read from the system property {@code slf4jtoys.meter.data.suffix}, defaulting to an empty string.
      * <p>
      * Setting a non-empty prefix (see also {@link #dataPrefix}) or suffix adds a small initialization cost to
      * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
@@ -200,7 +200,7 @@ public class MeterConfig {
      * Example: With prefix {@code "message."}, a logger {@code "a.b.c.MyClass"} becomes {@code "message.a.b.c.MyClass"}
      * for readable messages.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.message.prefix}, defaulting to an empty string.
+     * The value is read from the system property {@code slf4jtoys.meter.message.prefix}, defaulting to an empty string.
      * <p>
      * Setting a non-empty prefix or suffix (see also {@link #messageSuffix}) adds a small initialization cost to
      * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing
@@ -217,7 +217,7 @@ public class MeterConfig {
      * Example: With suffix {@code ".message"}, a logger {@code "a.b.c.MyClass"} becomes {@code "a.b.c.MyClass.message"}
      * for readable messages.
      * <p>
-     * Value is read from system property {@code slf4jtoys.meter.message.suffix}, defaulting to an empty string.
+     * The value is read from the system property {@code slf4jtoys.meter.message.suffix}, defaulting to an empty string.
      * <p>
      * Setting a non-empty prefix (see also {@link #messagePrefix}) or suffix adds a small initialization cost to
      * every new {@link Meter}, since the decorated logger name must be built and looked up instead of reusing

--- a/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java
@@ -32,7 +32,7 @@ import org.usefultoys.slf4j.utils.ConfigParser;
  * **Performance Note:** Some properties, such as progress reporting intervals, may impact performance
  * if configured with very low values.
  * <p>
- * This is a utility class and should not be instantiated.
+ * This is a utility class and is not meant to be instantiated.
  *
  * @author Daniel Felix Ferber
  * @author Co-authored-by: GitHub Copilot using Claude Sonnet 4.5

--- a/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
@@ -33,7 +33,7 @@ import org.usefultoys.slf4j.utils.ConfigParser;
  * **Security Note:** Some values retrieved from the environment (e.g., system properties, user information)
  * may contain sensitive data. Consider sanitizing reports if logs are shared externally.
  * <p>
- * This is a utility class and should not be instantiated.
+ * This is a utility class and is not meant to be instantiated.
  *
  * @author Daniel Felix Ferber
  * @see Reporter

--- a/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
@@ -309,8 +309,8 @@ public class ReporterConfig {
     }
 
     /**
-     * Resets all configuration properties to their default values.
-     * This method is useful for testing purposes or when reinitializing the configuration.
+     * Resets the configuration properties to their default values.
+     * This method is useful for testing or re-initializing the configuration.
      */
     public void reset() {
         System.clearProperty(ReporterConfig.PROP_VM);

--- a/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
@@ -313,27 +313,27 @@ public class ReporterConfig {
      * This method is useful for testing or re-initializing the configuration.
      */
     public void reset() {
-        System.clearProperty(ReporterConfig.PROP_VM);
-        System.clearProperty(ReporterConfig.PROP_FILE_SYSTEM);
-        System.clearProperty(ReporterConfig.PROP_MEMORY);
-        System.clearProperty(ReporterConfig.PROP_USER);
-        System.clearProperty(ReporterConfig.PROP_PROPERTIES);
-        System.clearProperty(ReporterConfig.PROP_ENVIRONMENT);
-        System.clearProperty(ReporterConfig.PROP_PHYSICAL_SYSTEM);
-        System.clearProperty(ReporterConfig.PROP_OPERATING_SYSTEM);
-        System.clearProperty(ReporterConfig.PROP_CALENDAR);
-        System.clearProperty(ReporterConfig.PROP_LOCALE);
-        System.clearProperty(ReporterConfig.PROP_CHARSET);
-        System.clearProperty(ReporterConfig.PROP_NETWORK_INTERFACE);
-        System.clearProperty(ReporterConfig.PROP_SSL_CONTEXT);
-        System.clearProperty(ReporterConfig.PROP_DEFAULT_TRUST_KEYSTORE);
-        System.clearProperty(ReporterConfig.PROP_JVM_ARGUMENTS);
-        System.clearProperty(ReporterConfig.PROP_CLASSPATH);
-        System.clearProperty(ReporterConfig.PROP_GARBAGE_COLLECTOR);
-        System.clearProperty(ReporterConfig.PROP_SECURITY_PROVIDERS);
-        System.clearProperty(ReporterConfig.PROP_CONTAINER_INFO);
-        System.clearProperty(ReporterConfig.PROP_NAME);
-        System.clearProperty(ReporterConfig.PROP_FORBIDDEN_PROPERTY_NAMES_REGEX);
+        System.clearProperty(PROP_VM);
+        System.clearProperty(PROP_FILE_SYSTEM);
+        System.clearProperty(PROP_MEMORY);
+        System.clearProperty(PROP_USER);
+        System.clearProperty(PROP_PROPERTIES);
+        System.clearProperty(PROP_ENVIRONMENT);
+        System.clearProperty(PROP_PHYSICAL_SYSTEM);
+        System.clearProperty(PROP_OPERATING_SYSTEM);
+        System.clearProperty(PROP_CALENDAR);
+        System.clearProperty(PROP_LOCALE);
+        System.clearProperty(PROP_CHARSET);
+        System.clearProperty(PROP_NETWORK_INTERFACE);
+        System.clearProperty(PROP_SSL_CONTEXT);
+        System.clearProperty(PROP_DEFAULT_TRUST_KEYSTORE);
+        System.clearProperty(PROP_JVM_ARGUMENTS);
+        System.clearProperty(PROP_CLASSPATH);
+        System.clearProperty(PROP_GARBAGE_COLLECTOR);
+        System.clearProperty(PROP_SECURITY_PROVIDERS);
+        System.clearProperty(PROP_CONTAINER_INFO);
+        System.clearProperty(PROP_NAME);
+        System.clearProperty(PROP_FORBIDDEN_PROPERTY_NAMES_REGEX);
         init();
     }
 }

--- a/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
@@ -263,8 +263,12 @@ public class ReporterConfig {
 
 
     /**
-     * Initializes the configuration attributes by reading the corresponding system properties.
-     * This method should be called at application startup to ensure they are properly initialized.
+     * Initializes the configuration properties by reading values from system properties.
+     * <p>
+     * This method is automatically called in a static initializer when the class is first loaded.
+     * It can also be called manually to reload configuration from system properties after they have been modified.
+     * <p>
+     * For consistent behavior, ensure system properties are set before this class is first accessed.
      */
     public void init() {
         reportVM = ConfigParser.getBooleanProperty(PROP_VM, true);

--- a/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java
@@ -92,7 +92,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes Java Virtual Machine (JVM) information.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.vm}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.vm}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportVM;
@@ -100,7 +100,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes information about available and used disk space for file system roots.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.fileSystem}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.fileSystem}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportFileSystem;
@@ -108,7 +108,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes memory usage information (heap, non-heap, etc.).
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.memory}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.memory}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportMemory;
@@ -116,7 +116,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes current user information (name, home directory).
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.user}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.user}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportUser;
@@ -124,7 +124,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes all Java system properties.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.properties}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.properties}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportProperties;
@@ -132,7 +132,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes all environment variables.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.environment}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.environment}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportEnvironment;
@@ -140,7 +140,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes physical machine information (e.g., number of processors).
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.physicalSystem}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.physicalSystem}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportPhysicalSystem;
@@ -148,7 +148,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes operating system information (name, version, architecture).
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.operatingSystem}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.operatingSystem}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportOperatingSystem;
@@ -156,7 +156,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes calendar, date, time, and timezone information.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.calendar}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.calendar}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportCalendar;
@@ -164,7 +164,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes current and available locales.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.locale}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.locale}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportLocale;
@@ -172,7 +172,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes current and available character sets.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.charset}. Defaults to {@code true}.
+     * The value is read from the system property {@code slf4jtoys.report.charset}, defaulting to {@code true}.
      * Can be changed at runtime.
      */
     public boolean reportCharset;
@@ -181,7 +181,7 @@ public class ReporterConfig {
      * Whether the default report includes network interface information.
      * <p>
      * This operation may block the thread for a significant amount of time.
-     * Controlled by the system property {@code slf4jtoys.report.networkInterface}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.networkInterface}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportNetworkInterface;
@@ -189,7 +189,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes SSL context information (e.g., protocols, cipher suites).
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.SSLContext}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.SSLContext}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportSSLContext;
@@ -197,7 +197,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes information about the default trusted keystore.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.defaultTrustKeyStore}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.defaultTrustKeyStore}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportDefaultTrustKeyStore;
@@ -205,7 +205,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes JVM arguments.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.jvmArguments}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.jvmArguments}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportJvmArguments;
@@ -213,7 +213,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes classpath information.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.classpath}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.classpath}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportClasspath;
@@ -221,7 +221,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes garbage collector information.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.garbageCollector}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.garbageCollector}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportGarbageCollector;
@@ -229,7 +229,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes security providers information.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.securityProviders}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.securityProviders}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportSecurityProviders;
@@ -237,7 +237,7 @@ public class ReporterConfig {
     /**
      * Whether the default report includes container information.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.containerInfo}. Defaults to {@code false}.
+     * The value is read from the system property {@code slf4jtoys.report.containerInfo}, defaulting to {@code false}.
      * Can be changed at runtime.
      */
     public boolean reportContainerInfo;
@@ -245,7 +245,7 @@ public class ReporterConfig {
     /**
      * Defines the default name used for the logger that prints reports.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.name}. Defaults to {@code "report"}.
+     * The value is read from the system property {@code slf4jtoys.report.name}, defaulting to {@code "report"}.
      * Can be changed at runtime.
      */
     public String name;
@@ -254,8 +254,8 @@ public class ReporterConfig {
      * A regular expression used to identify sensitive property names (system properties or environment variables)
      * whose values should be censored in reports.
      * <p>
-     * Controlled by the system property {@code slf4jtoys.report.forbiddenPropertyNamesRegex}.
-     * Defaults to {@code "(?i).*password.*|.*secret.*|.*key.*|.*token.*"}.
+     * The value is read from the system property {@code slf4jtoys.report.forbiddenPropertyNamesRegex}, defaulting
+     * to {@code "(?i).*password.*|.*secret.*|.*key.*|.*token.*"}.
      * The {@code (?i)} flag makes the regex case-insensitive.
      * Can be changed at runtime.
      */

--- a/src/main/java/org/usefultoys/slf4j/watcher/Watcher.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/Watcher.java
@@ -75,8 +75,20 @@ public class Watcher extends WatcherData implements Runnable {
      */
     public Watcher(final String name) {
         super(Session.shortSessionUuid());
-        messageLogger = org.slf4j.LoggerFactory.getLogger(messagePrefix + name + messageSuffix);
-        dataLogger = org.slf4j.LoggerFactory.getLogger(dataPrefix + name + dataSuffix);
+        final Logger base = org.slf4j.LoggerFactory.getLogger(name);
+        messageLogger = resolveDecoratedLogger(base, messagePrefix, messageSuffix);
+        dataLogger = resolveDecoratedLogger(base, dataPrefix, dataSuffix);
+    }
+
+    /**
+     * Resolves the logger to use for decorated (prefixed/suffixed) output. Reuses {@code base} directly when both
+     * {@code prefix} and {@code suffix} are empty (the default), avoiding a redundant name concatenation and
+     * backend logger-registry lookup for the common case.
+     */
+    private static Logger resolveDecoratedLogger(final Logger base, final String prefix, final String suffix) {
+        return (prefix.isEmpty() && suffix.isEmpty())
+                ? base
+                : org.slf4j.LoggerFactory.getLogger(prefix + base.getName() + suffix);
     }
 
     /**

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
@@ -126,8 +126,12 @@ public class WatcherConfig {
     public String messageSuffix;
 
     /**
-     * Initializes the configuration properties. This method should be called at application startup to ensure
-     * consistent behavior.
+     * Initializes the configuration properties by reading values from system properties.
+     * <p>
+     * This method is automatically called in a static initializer when the class is first loaded.
+     * It can also be called manually to reload configuration from system properties after they have been modified.
+     * <p>
+     * For consistent behavior, ensure system properties are set before this class is first accessed.
      */
     public void init() {
         name = ConfigParser.getStringProperty(PROP_NAME, "watcher");

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
@@ -57,27 +57,27 @@ public class WatcherConfig {
     /**
      * The logger name used by watchers to write messages.
      * <p>
-     * Read from the system property {@code slf4jtoys.watcher.name}, defaulting to {@code "watcher"}.
+     * The value is read from the system property {@code slf4jtoys.watcher.name}, defaulting to {@code "watcher"}.
      */
     public String name;
 
     /**
      * The initial delay before the first status report by a scheduled watcher, in milliseconds.
      * <p>
-     * Read from the system property {@code slf4jtoys.watcher.delay}, defaulting to {@code 60000} (1 minute).
+     * The value is read from the system property {@code slf4jtoys.watcher.delay}, defaulting to {@code 60000} (1 minute).
      * The value can be suffixed with {@code ms}, {@code s}, {@code m}, or {@code h}.
      * <p>
-     * A new value can be assigned at runtime, but restarting scheduled watchers is required for the change to take effect.
+     * Can be changed at runtime, but restarting scheduled watchers is required for the change to take effect.
      */
     public long delayMilliseconds;
 
     /**
      * The interval between subsequent status reports by a scheduled watcher, in milliseconds.
      * <p>
-     * Read from the system property {@code slf4jtoys.watcher.period}, defaulting to {@code 600000} (10 minutes).
+     * The value is read from the system property {@code slf4jtoys.watcher.period}, defaulting to {@code 600000} (10 minutes).
      * The value can be suffixed with {@code ms}, {@code s}, {@code m}, or {@code h}.
      * <p>
-     * A new value can be assigned at runtime, but restarting scheduled watchers is required for the change to take effect.
+     * Can be changed at runtime, but restarting scheduled watchers is required for the change to take effect.
      */
     public long periodMilliseconds;
 
@@ -88,7 +88,7 @@ public class WatcherConfig {
      * <p>
      * Example: With prefix {@code "data."}, a logger named {@code "a.b.c.MyClass"} becomes {@code "data.a.b.c.MyClass"}.
      * <p>
-     * Read from the system property {@code slf4jtoys.watcher.data.prefix}, defaulting to an empty string.
+     * The value is read from the system property {@code slf4jtoys.watcher.data.prefix}, defaulting to an empty string.
      */
     public String dataPrefix;
 
@@ -99,7 +99,7 @@ public class WatcherConfig {
      * <p>
      * Example: With suffix {@code ".data"}, a logger named {@code "a.b.c.MyClass"} becomes {@code "a.b.c.MyClass.data"}.
      * <p>
-     * Read from the system property {@code slf4jtoys.watcher.data.suffix}, defaulting to an empty string.
+     * The value is read from the system property {@code slf4jtoys.watcher.data.suffix}, defaulting to an empty string.
      */
     public String dataSuffix;
 
@@ -110,7 +110,7 @@ public class WatcherConfig {
      * <p>
      * Example: With prefix {@code "message."}, a logger named {@code "a.b.c.MyClass"} becomes {@code "message.a.b.c.MyClass"}.
      * <p>
-     * Read from the system property {@code slf4jtoys.watcher.message.prefix}, defaulting to an empty string.
+     * The value is read from the system property {@code slf4jtoys.watcher.message.prefix}, defaulting to an empty string.
      */
     public String messagePrefix;
 
@@ -121,7 +121,7 @@ public class WatcherConfig {
      * <p>
      * Example: With suffix {@code ".message"}, a logger named {@code "a.b.c.MyClass"} becomes {@code "a.b.c.MyClass.message"}.
      * <p>
-     * Read from the system property {@code slf4jtoys.watcher.message.suffix}, defaulting to an empty string.
+     * The value is read from the system property {@code slf4jtoys.watcher.message.suffix}, defaulting to an empty string.
      */
     public String messageSuffix;
 

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
@@ -58,6 +58,7 @@ public class WatcherConfig {
      * The logger name used by watchers to write messages.
      * <p>
      * The value is read from the system property {@code slf4jtoys.watcher.name}, defaulting to {@code "watcher"}.
+     * Can be changed at runtime, but restarting scheduled watchers is required for the change to take effect.
      */
     public String name;
 
@@ -89,6 +90,7 @@ public class WatcherConfig {
      * Example: With prefix {@code "data."}, a logger named {@code "a.b.c.MyClass"} becomes {@code "data.a.b.c.MyClass"}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.watcher.data.prefix}, defaulting to an empty string.
+     * Can be changed at runtime, but restarting scheduled watchers is required for the change to take effect.
      */
     public String dataPrefix;
 
@@ -100,6 +102,7 @@ public class WatcherConfig {
      * Example: With suffix {@code ".data"}, a logger named {@code "a.b.c.MyClass"} becomes {@code "a.b.c.MyClass.data"}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.watcher.data.suffix}, defaulting to an empty string.
+     * Can be changed at runtime, but restarting scheduled watchers is required for the change to take effect.
      */
     public String dataSuffix;
 
@@ -111,6 +114,7 @@ public class WatcherConfig {
      * Example: With prefix {@code "message."}, a logger named {@code "a.b.c.MyClass"} becomes {@code "message.a.b.c.MyClass"}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.watcher.message.prefix}, defaulting to an empty string.
+     * Can be changed at runtime, but restarting scheduled watchers is required for the change to take effect.
      */
     public String messagePrefix;
 
@@ -122,6 +126,7 @@ public class WatcherConfig {
      * Example: With suffix {@code ".message"}, a logger named {@code "a.b.c.MyClass"} becomes {@code "a.b.c.MyClass.message"}.
      * <p>
      * The value is read from the system property {@code slf4jtoys.watcher.message.suffix}, defaulting to an empty string.
+     * Can be changed at runtime, but restarting scheduled watchers is required for the change to take effect.
      */
     public String messageSuffix;
 

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
@@ -31,6 +31,7 @@ import org.usefultoys.slf4j.utils.ConfigParser;
  *
  * @author Daniel Felix Ferber
  * @see Watcher
+ * @see WatcherData
  */
 @UtilityClass
 public class WatcherConfig {

--- a/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
+++ b/src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java
@@ -154,13 +154,13 @@ public class WatcherConfig {
      * This method is useful for testing or re-initializing the configuration.
      */
     public void reset() {
-        System.clearProperty(WatcherConfig.PROP_NAME);
-        System.clearProperty(WatcherConfig.PROP_DELAY);
-        System.clearProperty(WatcherConfig.PROP_PERIOD);
-        System.clearProperty(WatcherConfig.PROP_DATA_PREFIX);
-        System.clearProperty(WatcherConfig.PROP_DATA_SUFFIX);
-        System.clearProperty(WatcherConfig.PROP_MESSAGE_PREFIX);
-        System.clearProperty(WatcherConfig.PROP_MESSAGE_SUFFIX);
+        System.clearProperty(PROP_NAME);
+        System.clearProperty(PROP_DELAY);
+        System.clearProperty(PROP_PERIOD);
+        System.clearProperty(PROP_DATA_PREFIX);
+        System.clearProperty(PROP_DATA_SUFFIX);
+        System.clearProperty(PROP_MESSAGE_PREFIX);
+        System.clearProperty(PROP_MESSAGE_SUFFIX);
         init();
     }
 }


### PR DESCRIPTION
## Context

`Session`, `SessionConfig`, `SystemConfig`, `MeterConfig`, `ReporterConfig`, and `WatcherConfig` are the six classes that hold `slf4j-toys`' JVM-wide session identity and centralized configuration. They were built incrementally over time by different contributors, and while each one is internally coherent, they drifted apart in Javadoc wording, class layout, and a couple of small implementation details.

## Problem

A consistency review across all six classes found:

- **Inaccurate Javadoc**: `init()` in `SystemConfig`, `MeterConfig`, `ReporterConfig`, and `WatcherConfig` said "This method should be called at application startup" ❌ — but every one of these classes invokes `init()` automatically from a `static { init(); }` block at class-load time. Only `SessionConfig` documented this correctly.
- **Structural drift**: `MeterConfig` was missing the `// System property keys` section comment every other config class has, placed its `static { init(); }` block after the `PROP_*` constants instead of before (unlike all four siblings), and its own `PROP_*` constant order didn't match its field/`init()`/`reset()` order.
- **Five wordings for one fact**: "value is read from system property X, mutable at runtime" was phrased five different ways across the five config classes, including a bolded "Thread Safety" paragraph in `SessionConfig` found nowhere else, even though the underlying concurrency caveat is already stated once at the class level in all five.
- **Missing documentation**: 9 fields (`MeterConfig`'s and `WatcherConfig`'s `dataPrefix`/`dataSuffix`/`messagePrefix`/`messageSuffix`, plus `WatcherConfig.name`) had no statement at all about runtime mutability, unlike every other mutable field.
- **Two wordings for `reset()`** and **two wordings for "utility class, not instantiated"**, split roughly down the middle across the five classes.
- **Missing `@see WatcherData`** on `WatcherConfig`, even though its class Javadoc mentions `WatcherData` in prose (`MeterConfig` correctly lists both `Meter` and `MeterData`).
- **A stray `@author Co-authored-by: GitHub Copilot using Claude Sonnet 4.5`** tag in `MeterConfig`, misusing the Javadoc `@author` tag for a git-trailer convention.
- **Redundant self-qualification**: `ReporterConfig`/`WatcherConfig`'s `reset()` wrote `System.clearProperty(ReporterConfig.PROP_X)` / `System.clearProperty(WatcherConfig.PROP_X)` instead of the bare constant used everywhere else.
- **An implementation asymmetry**: `Meter` avoids a redundant logger-registry lookup when prefix/suffix are both empty (`resolveDecoratedLogger`'s fast path); `Watcher` always did the concatenation + lookup for both its message and data loggers, even in the (default) all-empty case.

## Solution

Each finding above was fixed in its own independent, reviewable commit:

1. `docs(config): fix init() javadoc to describe auto-invocation` — align `init()` Javadoc with `SessionConfig`'s accurate description across the other four classes.
2. `refactor(meter): align MeterConfig layout with other config classes` — move the static block and add the missing section comment.
3. `refactor(meter): reorder MeterConfig PROP_* constants to match fields` — make the constant order match field/`init()`/`reset()` order.
4. `docs(config): unify field-level runtime-mutability javadoc wording` — collapse five templates into one canonical sentence, preserving every field's unique extra caveats.
5. `docs(config): document runtime-mutability for prefix/suffix/name fields` — add the missing statement to the 9 affected fields.
6. `docs(config): unify reset() javadoc wording across config classes`.
7. `docs(config): unify utility-class instantiation wording`.
8. `docs(watcher): add missing @see WatcherData tag to WatcherConfig`.
9. `docs(meter): remove non-standard @author co-author tag from MeterConfig`.
10. `style(config): drop redundant class-name qualifier in reset()`.
11. `perf(watcher): add Meter-style logger fast-path to Watcher` — mirrors `Meter.resolveDecoratedLogger`, reusing the base logger when prefix and suffix are both empty instead of resolving an identical logger name twice.

No public API or observable behavior changed except commit 11, which is a pure lookup-avoidance optimization: the logger names `Watcher` produces are unchanged for any given `WatcherConfig` prefix/suffix combination.

## API Changes

None. All changes are Javadoc, comment placement/ordering, or an internal-only logger-resolution optimization with identical externally-observable output.

## Code Changes

- `src/main/java/org/usefultoys/slf4j/SessionConfig.java` — Javadoc only
- `src/main/java/org/usefultoys/slf4j/SystemConfig.java` — Javadoc only
- `src/main/java/org/usefultoys/slf4j/meter/MeterConfig.java` — Javadoc, layout, and constant ordering
- `src/main/java/org/usefultoys/slf4j/report/ReporterConfig.java` — Javadoc and a style fix
- `src/main/java/org/usefultoys/slf4j/watcher/WatcherConfig.java` — Javadoc and a style fix
- `src/main/java/org/usefultoys/slf4j/watcher/Watcher.java` — internal logger-resolution optimization (no test changes needed; existing `WatcherTest` covers the constructor)

No test files were added or modified; existing tests already cover all touched constructors and behavior.

## Test Results

Full suite passes on both tiers after rebasing onto latest `main`:
- `.\mvnw test` (core, slf4j-2.0): all tests pass
- `.\mvnw test -P slf4j-2.0,with-logback`: all 1525 tests pass, including all 5 `WatcherTest` cases exercising the changed constructor

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
